### PR TITLE
MODMARCMIG-23 - Provide necessary permission to call bulk instances upsert endpoint 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,3 +11,4 @@
 * update documentation ([MODMARCMIG-16](https://issues.folio.org/browse/MODMARCMIG-16))
 * prepare chunks of MARC Bibs for mapping ([MODMARCMIG-17](https://folio-org.atlassian.net/browse/MODMARCMIG-17))
 * extend the data saving service to save re-mapped Instances ([MODMARCMIG-19](https://folio-org.atlassian.net/browse/MODMARCMIG-19))
+* provide necessary module permission to call bulk instances upsert endpoint ([MODMARCMIG-23](https://folio-org.atlassian.net/browse/MODMARCMIG-23))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -66,7 +66,8 @@
             "marc-migrations.operations.item.put"
           ],
           "modulePermissions": [
-            "inventory-storage.authorities.bulk.post"
+            "inventory-storage.authorities.bulk.post",
+            "inventory-storage.instances.bulk.post"
           ]
         }
       ]

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -29,6 +29,10 @@
     {
       "id": "mapping-metadata-provider",
       "version": "1.0"
+    },
+    {
+      "id": "instance-storage-bulk",
+      "version": "1.0"
     }
   ],
   "provides": [


### PR DESCRIPTION
## Purpose
to provide permission that is required to call bulk instances upsert endpoint during migration flow initiated for instances to save results of instances remapping

## Learning
[MODMARCMIG-23](https://issues.folio.org/browse/MODMARCMIG-23)
[MODINVSTOR-1225](https://issues.folio.org/browse/MODINVSTOR-1225)

Relates to: https://github.com/folio-org/mod-inventory-storage/pull/1062
