### PR TITLE
MODMARCMIG-51: Add API to get collection of migration operations

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 * Requires `API_NAME vX.Y`
 
 ### Features
-* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Add API to get collection of migrations operations ([MODMARCMIG-51](https://folio-org.atlassian.net/browse/MODMARCMIG-51))
 
 ### Bug fixes
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -56,6 +56,15 @@
           "methods": [
             "GET"
           ],
+          "pathPattern": "/marc-migrations",
+          "permissionsRequired": [
+            "marc-migrations.operations.collection.get"
+          ]
+        },
+        {
+          "methods": [
+            "GET"
+          ],
           "pathPattern": "/marc-migrations/{id}",
           "permissionsRequired": [
             "marc-migrations.operations.item.get"
@@ -117,6 +126,11 @@
       "description": "Create MARC Migrations Operation"
     },
     {
+      "permissionName": "marc-migrations.operations.collection.get",
+      "displayName": "MARC Migrations - Get Marc Migration operations",
+      "description": "Get MARC Migrations Operations"
+    },
+    {
       "permissionName": "marc-migrations.operations.item.get",
       "displayName": "MARC Migrations - Get operation",
       "description": "Get MARC Migrations Operation by ID"
@@ -131,6 +145,7 @@
       "displayName": "MARC Migrations - all permissions",
       "description": "Entire set of permissions needed to use MARC migrations",
       "subPermissions": [
+        "marc-migrations.operations.collection.get",
         "marc-migrations.operations.item.post",
         "marc-migrations.operations.item.get",
         "marc-migrations.operations.item.put"

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -21,6 +21,8 @@
         * [Response](#response)
     * [Tracking the state of MARC Migration operation](#tracking-the-state-of-marc-migration-operation)
         * [Response](#response-1)
+    * [Retirieving the collection of MARC Migration operations](#retirieving-the-collection-of-marc-migration-operations)
+        * [Response](#response-2)
     * [Initiating the Data Saving phase for the MARC Migration operation](#initiating-the-data-saving-phase-for-the-marc-migration-operation)
         * [Request body](#request-body-1)
     * [Full scenario for Authority records migration](#full-scenario-for-authority-records-migration)
@@ -114,11 +116,12 @@ docker compose up --build --force-recreate --no-deps
 ### API marc-migrations
 The API provides management endpoint for MARC Migrations
 
-| METHOD  | URL                              | Required permissions                   | DESCRIPTION                                                       |
-|:--------|:---------------------------------|:---------------------------------------|:------------------------------------------------------------------|
-| POST    | `/marc-migrations`               | `marc-migrations.operations.item.post` | Register new MARC Migration operation                             |
-| GET     | `/marc-migrations/{operationId}` | `marc-migrations.operations.item.get`  | Track the state of MARC Migration operation by operation ID       |
-| PUT     | `/marc-migrations/{operationId}` | `marc-migrations.operations.item.put`  | Initiating the Data Saving phase for the MARC Migration operation |
+| METHOD  | URL                              | Required permissions                        | DESCRIPTION                                                       |
+|:--------|:---------------------------------|:--------------------------------------------|:------------------------------------------------------------------|
+| POST    | `/marc-migrations`               | `marc-migrations.operations.item.post`      | Register new MARC Migration operation                             |
+| GET     | `/marc-migrations`               | `marc-migrations.operations.collection.get` | Get collection of MARC Migration operations                       |
+| GET     | `/marc-migrations/{operationId}` | `marc-migrations.operations.item.get`       | Track the state of MARC Migration operation by operation ID       |
+| PUT     | `/marc-migrations/{operationId}` | `marc-migrations.operations.item.put`       | Initiating the Data Saving phase for the MARC Migration operation |
 
 
 ### Registering MARC Migration operation
@@ -179,6 +182,29 @@ Response will have the following values for ```"status"``` depending on whether 
 * ```"data_mapping_failed"``` or ```"data_saving_failed"``` - job is finished with failure for data mapping or data saving
 
 Also, when the job is finished successfully fields ```"mappedNumOfRecords"``` and ```"savedNumOfRecords"``` should have the values equal to the one from ```"totalNumOfRecords"```
+
+### Retirieving the collection of MARC Migration operations
+
+All existing migration operations can be listed by calling the ```GET /marc-migrations``` endpoint. This will return the collection of all migration operations with their status and other details.
+The API is pageable and accepts `offset` and `limit` (optional) query parameters. Also, using the `entityType` (optional) query parameter migrations operations of specific entity type can be filtered.
+
+```GET /marc-migrations?entityType=authority?offset=0&limit=10```
+##### Response
+```json
+{
+  "migrationOperations": {
+    "id": "99fa24e1-d0de-4f20-a122-5ecfe9dec539",
+    "userId": "acf0af69-a463-458e-adc6-392045739ba0",
+    "entityType": "authority",
+    "operationType": "remapping",
+    "status": "data_mapping",
+    "totalNumOfRecords": 1141,
+    "mappedNumOfRecords": 850,
+    "savedNumOfRecords": 0
+  },
+  "totalRecords": 1
+}
+```
 
 ### Initiating the Data Saving phase for the MARC Migration operation
 

--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,7 @@
                 <dateLibrary>java8</dateLibrary>
                 <interfaceOnly>true</interfaceOnly>
                 <useSpringBoot3>true</useSpringBoot3>
+                <useEnumCaseInsensitive>true</useEnumCaseInsensitive>
               </configOptions>
             </configuration>
           </execution>

--- a/src/main/java/org/folio/marc/migrations/controllers/MarcMigrationsController.java
+++ b/src/main/java/org/folio/marc/migrations/controllers/MarcMigrationsController.java
@@ -2,7 +2,9 @@ package org.folio.marc.migrations.controllers;
 
 import java.util.UUID;
 import org.folio.marc.migrations.controllers.delegates.MarcMigrationsService;
+import org.folio.marc.migrations.domain.dto.EntityType;
 import org.folio.marc.migrations.domain.dto.MigrationOperation;
+import org.folio.marc.migrations.domain.dto.MigrationOperationCollection;
 import org.folio.marc.migrations.domain.dto.NewMigrationOperation;
 import org.folio.marc.migrations.domain.dto.SaveMigrationOperation;
 import org.folio.marc.migrations.rest.resource.MarcMigrationsApi;
@@ -26,6 +28,12 @@ public class MarcMigrationsController implements MarcMigrationsApi {
                                                                  NewMigrationOperation newMigrationOperation) {
     var operation = migrationsService.createNewMigration(newMigrationOperation);
     return ResponseEntity.status(HttpStatus.CREATED).body(operation);
+  }
+
+  @Override
+  public ResponseEntity<MigrationOperationCollection> getMarcMigrations(Integer offset, Integer limit,
+                                                                        EntityType entityType) {
+    return ResponseEntity.ok(migrationsService.getMarcMigrations(offset, limit, entityType));
   }
 
   @Override

--- a/src/main/java/org/folio/marc/migrations/controllers/mappers/MarcMigrationMapper.java
+++ b/src/main/java/org/folio/marc/migrations/controllers/mappers/MarcMigrationMapper.java
@@ -2,7 +2,9 @@ package org.folio.marc.migrations.controllers.mappers;
 
 import java.sql.Timestamp;
 import java.time.OffsetDateTime;
+import java.util.List;
 import org.folio.marc.migrations.domain.dto.MigrationOperation;
+import org.folio.marc.migrations.domain.dto.MigrationOperationCollection;
 import org.folio.marc.migrations.domain.dto.NewMigrationOperation;
 import org.folio.marc.migrations.domain.entities.Operation;
 import org.folio.marc.migrations.utils.DateUtils;
@@ -10,6 +12,7 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
 import org.mapstruct.ReportingPolicy;
+import org.springframework.data.domain.Page;
 
 @Mapper(
     unmappedTargetPolicy = ReportingPolicy.IGNORE,
@@ -30,6 +33,14 @@ public interface MarcMigrationMapper {
   Operation toEntity(NewMigrationOperation migrationOperation);
 
   MigrationOperation toDto(Operation operation);
+
+  List<MigrationOperation> toDtoList(Iterable<Operation> authorityNoteTypeIterable);
+
+  default MigrationOperationCollection toDtoCollection(
+      Page<Operation> operations) {
+    var migrationOperations = toDtoList(operations);
+    return new MigrationOperationCollection((int) operations.getTotalElements(), migrationOperations);
+  }
 
   default OffsetDateTime map(Timestamp value) {
     return DateUtils.fromTimestamp(value);

--- a/src/main/java/org/folio/marc/migrations/domain/converters/EntityNameToEntityTypeConverter.java
+++ b/src/main/java/org/folio/marc/migrations/domain/converters/EntityNameToEntityTypeConverter.java
@@ -1,0 +1,14 @@
+package org.folio.marc.migrations.domain.converters;
+
+import org.folio.marc.migrations.domain.dto.EntityType;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class EntityNameToEntityTypeConverter implements Converter<String, EntityType> {
+
+  @Override
+  public EntityType convert(String source) {
+    return EntityType.fromValue(source);
+  }
+}

--- a/src/main/java/org/folio/marc/migrations/domain/repositories/OperationRepository.java
+++ b/src/main/java/org/folio/marc/migrations/domain/repositories/OperationRepository.java
@@ -3,6 +3,7 @@ package org.folio.marc.migrations.domain.repositories;
 import java.util.UUID;
 import org.folio.marc.migrations.domain.entities.Operation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-public interface OperationRepository extends JpaRepository<Operation, UUID> {
+public interface OperationRepository extends JpaRepository<Operation, UUID>, JpaSpecificationExecutor<Operation> {
 }

--- a/src/main/java/org/folio/marc/migrations/services/operations/OperationsService.java
+++ b/src/main/java/org/folio/marc/migrations/services/operations/OperationsService.java
@@ -11,12 +11,18 @@ import org.folio.marc.migrations.domain.repositories.OperationRepository;
 import org.folio.marc.migrations.services.jdbc.AuthorityJdbcService;
 import org.folio.marc.migrations.services.jdbc.InstanceJdbcService;
 import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.data.OffsetRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 
 @Log4j2
 @Service
 @RequiredArgsConstructor
 public class OperationsService {
+
+  private static final String ORDER_BY_FIELD = "startTimeMapping";
 
   private final FolioExecutionContext context;
   private final OperationRepository repository;
@@ -42,5 +48,16 @@ public class OperationsService {
   public Optional<Operation> getOperation(UUID operationId) {
     log.info("getOperation::Get operation by ID: {}", operationId);
     return repository.findById(operationId);
+  }
+
+  public Page<Operation> getOperations(Integer offset, Integer limit, EntityType entityType) {
+    var pageable = new OffsetRequest(offset, limit, Sort.by(Sort.Order.desc(ORDER_BY_FIELD)));
+    if (entityType == null) {
+      return repository.findAll(pageable);
+    }
+
+    Specification<Operation> specification = (root, query, builder) ->
+        builder.equal(root.get("entityType"), entityType);
+    return repository.findAll(specification, pageable);
   }
 }

--- a/src/main/resources/swagger.api/marc-migrations.yaml
+++ b/src/main/resources/swagger.api/marc-migrations.yaml
@@ -6,6 +6,83 @@ info:
 
 paths:
   /marc-migrations:
+    get:
+      summary: Get MARC migration operations
+      operationId: getMarcMigrations
+      tags:
+        - marc-migrations
+      parameters:
+        - in: query
+          name: offset
+          description: Skip over a number of migrations by specifying an offset value for the query.
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 1000
+            default: 0
+        - in: query
+          name: limit
+          description: Limit the number of migration operations returned in the response.
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+            maximum: 1000
+            default: 100
+        - name: entityType
+          in: query
+          required: false
+          description: Migration Entity Type to filter by
+          schema:
+            $ref: "#/components/schemas/EntityType"
+      responses:
+        '200':
+          description: Retrieved MARC migration operations collection
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MigrationOperationCollection'
+              example:
+                migrationOperations:
+                  - id: 118dbd8c-5ba0-47a9-a850-34bbb1dbf3b7
+                    userId: 0db8f753-6864-452c-9b49-5362a20188b5
+                    entityType: authority
+                    operationType: remapping
+                    status: new
+                    totalNumOfRecords: 10000
+                  - id: 46669e09-8b45-4ede-afbd-ca73bb89cdb3
+                    userId: 0db8f753-6864-452c-9b49-5362a20188b5
+                    entityType: instance
+                    operationType: remapping
+                    status: new
+                    totalNumOfRecords: 50000
+                totalRecords: 2
+        '400':
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                InvalidMethodArgumentTypeMismatch:
+                  value:
+                    message: "Method parameter 'entityType': Failed to convert value of type 'java.lang.String' to required type"
+                    type: 'MethodArgumentTypeMismatchException'
+                    parameters:
+                      - key: 'entityType'
+                        value: 'unexpected_entity_name'
+        '500':
+          description: Unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              examples:
+                UnexpectedError:
+                  value:
+                    message: 'Unexpected error'
+                    type: 'NullPointerException'
     post:
       summary: Register new MARC migration operation
       operationId: createMarcMigrations
@@ -185,6 +262,21 @@ components:
           $ref: '#/components/schemas/EntityType'
         operationType:
           $ref: '#/components/schemas/OperationType'
+
+    MigrationOperationCollection:
+      type: object
+      properties:
+        totalRecords:
+          description: Total number of records
+          type: integer
+        migrationOperations:
+          description: List of MARC migration operations
+          type: array
+          items:
+            $ref: '#/components/schemas/MigrationOperation'
+      required:
+        - totalRecords
+        - migrationOperations
 
     MigrationOperation:
       type: object

--- a/src/test/java/org/folio/marc/migrations/controllers/MarcMigrationsControllerIT.java
+++ b/src/test/java/org/folio/marc/migrations/controllers/MarcMigrationsControllerIT.java
@@ -7,6 +7,8 @@ import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.marc.migrations.domain.dto.EntityType.AUTHORITY;
+import static org.folio.marc.migrations.domain.dto.EntityType.INSTANCE;
 import static org.folio.marc.migrations.domain.dto.MigrationOperationStatus.DATA_MAPPING;
 import static org.folio.marc.migrations.domain.dto.MigrationOperationStatus.DATA_MAPPING_COMPLETED;
 import static org.folio.marc.migrations.domain.dto.MigrationOperationStatus.DATA_MAPPING_FAILED;
@@ -14,6 +16,7 @@ import static org.folio.marc.migrations.domain.dto.MigrationOperationStatus.DATA
 import static org.folio.marc.migrations.domain.dto.MigrationOperationStatus.DATA_SAVING_COMPLETED;
 import static org.folio.marc.migrations.domain.dto.MigrationOperationStatus.DATA_SAVING_FAILED;
 import static org.folio.marc.migrations.domain.dto.MigrationOperationStatus.NEW;
+import static org.folio.marc.migrations.domain.dto.OperationType.REMAPPING;
 import static org.folio.marc.migrations.domain.entities.types.StepStatus.COMPLETED;
 import static org.folio.support.DatabaseHelper.CHUNKS_TABLE;
 import static org.folio.support.DatabaseHelper.CHUNK_STEPS_TABLE;
@@ -23,6 +26,7 @@ import static org.folio.support.TestConstants.USER_ID;
 import static org.folio.support.TestConstants.marcMigrationEndpoint;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -34,10 +38,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.github.tomakehurst.wiremock.admin.NotFoundException;
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder;
+import java.util.Comparator;
 import java.util.UUID;
 import lombok.SneakyThrows;
 import org.folio.marc.migrations.domain.dto.EntityType;
 import org.folio.marc.migrations.domain.dto.MigrationOperation;
+import org.folio.marc.migrations.domain.dto.MigrationOperationCollection;
 import org.folio.marc.migrations.domain.dto.MigrationOperationStatus;
 import org.folio.marc.migrations.domain.dto.NewMigrationOperation;
 import org.folio.marc.migrations.domain.dto.OperationType;
@@ -55,6 +61,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @IntegrationTest
 @DatabaseCleanup(tables = {CHUNK_STEPS_TABLE, CHUNKS_TABLE, OPERATION_TABLE})
@@ -70,16 +77,16 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
   void createNewMigrationAuthority_positive() throws Exception {
     // Arrange
     var migrationOperation = new NewMigrationOperation()
-      .operationType(OperationType.REMAPPING)
-      .entityType(EntityType.AUTHORITY);
+      .operationType(REMAPPING)
+      .entityType(AUTHORITY);
 
     // Act & Assert
     var result = tryPost(marcMigrationEndpoint(), migrationOperation)
       .andExpect(status().isCreated())
       .andExpect(jsonPath("id", notNullValue(UUID.class)))
       .andExpect(jsonPath("userId", is(USER_ID)))
-      .andExpect(jsonPath("operationType", is(OperationType.REMAPPING.getValue())))
-      .andExpect(jsonPath("entityType", is(EntityType.AUTHORITY.getValue())))
+      .andExpect(jsonPath("operationType", is(REMAPPING.getValue())))
+      .andExpect(jsonPath("entityType", is(AUTHORITY.getValue())))
       .andExpect(operationStatus(NEW))
       .andExpect(totalRecords(87))
       .andExpect(mappedRecords(0))
@@ -116,7 +123,7 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
   void createNewMigrationInstance_positive() throws Exception {
     // Arrange
     var migrationOperation = new NewMigrationOperation()
-        .operationType(OperationType.REMAPPING)
+        .operationType(REMAPPING)
         .entityType(EntityType.INSTANCE);
 
     // Act & Assert
@@ -124,7 +131,7 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
         .andExpect(status().isCreated())
         .andExpect(jsonPath("id", notNullValue(UUID.class)))
         .andExpect(jsonPath("userId", is(USER_ID)))
-        .andExpect(jsonPath("operationType", is(OperationType.REMAPPING.getValue())))
+        .andExpect(jsonPath("operationType", is(REMAPPING.getValue())))
         .andExpect(jsonPath("entityType", is(EntityType.INSTANCE.getValue())))
         .andExpect(operationStatus(NEW))
         .andExpect(totalRecords(11))
@@ -166,16 +173,16 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
     final var stub = wireMock.stubFor(get(urlPathEqualTo("/mapping-metadata/type/marc-authority"))
       .willReturn(notFound()));
     var migrationOperation = new NewMigrationOperation()
-      .operationType(OperationType.REMAPPING)
-      .entityType(EntityType.AUTHORITY);
+      .operationType(REMAPPING)
+      .entityType(AUTHORITY);
 
     // Act & Assert
     var result = tryPost(marcMigrationEndpoint(), migrationOperation)
       .andExpect(status().isCreated())
       .andExpect(jsonPath("id", notNullValue(UUID.class)))
       .andExpect(jsonPath("userId", is(USER_ID)))
-      .andExpect(jsonPath("operationType", is(OperationType.REMAPPING.getValue())))
-      .andExpect(jsonPath("entityType", is(EntityType.AUTHORITY.getValue())))
+      .andExpect(jsonPath("operationType", is(REMAPPING.getValue())))
+      .andExpect(jsonPath("entityType", is(AUTHORITY.getValue())))
       .andExpect(operationStatus(NEW))
       .andExpect(totalRecords(87))
       .andExpect(mappedRecords(0))
@@ -215,16 +222,16 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
     // Arrange
     doThrow(IllegalStateException.class).when(s3Client).upload(any(), any());
     var migrationOperation = new NewMigrationOperation()
-      .operationType(OperationType.REMAPPING)
-      .entityType(EntityType.AUTHORITY);
+      .operationType(REMAPPING)
+      .entityType(AUTHORITY);
 
     // Act & Assert
     var result = tryPost(marcMigrationEndpoint(), migrationOperation)
       .andExpect(status().isCreated())
       .andExpect(jsonPath("id", notNullValue(UUID.class)))
       .andExpect(jsonPath("userId", is(USER_ID)))
-      .andExpect(jsonPath("operationType", is(OperationType.REMAPPING.getValue())))
-      .andExpect(jsonPath("entityType", is(EntityType.AUTHORITY.getValue())))
+      .andExpect(jsonPath("operationType", is(REMAPPING.getValue())))
+      .andExpect(jsonPath("entityType", is(AUTHORITY.getValue())))
       .andExpect(operationStatus(NEW))
       .andExpect(totalRecords(87))
       .andExpect(mappedRecords(0))
@@ -260,7 +267,7 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
   @Test
   void createNewMigration_negative_operationTypeIsNull() throws Exception {
     // Arrange
-    var migrationOperation = new NewMigrationOperation().entityType(EntityType.AUTHORITY);
+    var migrationOperation = new NewMigrationOperation().entityType(AUTHORITY);
 
     // Act & Assert
     tryPost(marcMigrationEndpoint(), migrationOperation)
@@ -274,7 +281,7 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
   @Test
   void createNewMigration_negative_entityTypeIsNull() throws Exception {
     // Arrange
-    var migrationOperation = new NewMigrationOperation().operationType(OperationType.REMAPPING);
+    var migrationOperation = new NewMigrationOperation().operationType(REMAPPING);
 
     // Act & Assert
     tryPost(marcMigrationEndpoint(), migrationOperation)
@@ -290,7 +297,7 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
     // Arrange
     var migrationOperation = new NewMigrationOperation()
       .operationType(OperationType.IMPORT)
-      .entityType(EntityType.AUTHORITY);
+      .entityType(AUTHORITY);
 
     // Act & Assert
     tryPost(marcMigrationEndpoint(), migrationOperation)
@@ -305,8 +312,8 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
   void getMigrationById_positive() throws Exception {
     // Arrange
     var migrationOperation = new NewMigrationOperation()
-      .operationType(OperationType.REMAPPING)
-      .entityType(EntityType.AUTHORITY);
+      .operationType(REMAPPING)
+      .entityType(AUTHORITY);
     var postResult = doPost(marcMigrationEndpoint(), migrationOperation).andReturn();
     var operationId = contentAsObj(postResult, MigrationOperation.class).getId();
 
@@ -315,8 +322,8 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
       .andExpect(status().isOk())
       .andExpect(jsonPath("id", is(operationId.toString())))
       .andExpect(jsonPath("userId", is(USER_ID)))
-      .andExpect(jsonPath("operationType", is(OperationType.REMAPPING.getValue())))
-      .andExpect(jsonPath("entityType", is(EntityType.AUTHORITY.getValue())))
+      .andExpect(jsonPath("operationType", is(REMAPPING.getValue())))
+      .andExpect(jsonPath("entityType", is(AUTHORITY.getValue())))
       .andExpect(jsonPath("status",
           oneOf(NEW.getValue(), DATA_MAPPING.getValue(), DATA_MAPPING_COMPLETED.getValue())))
       .andExpect(totalRecords(87))
@@ -327,6 +334,90 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
       assertThat(databaseHelper.getOperation(TENANT_ID, operationId).getStatus())
           .isEqualTo(OperationStatusType.DATA_MAPPING_COMPLETED)
     );
+  }
+
+  @Test
+  @SneakyThrows
+  void getMigrationCollection_positive() {
+    var migrationOperation1 = new NewMigrationOperation()
+        .operationType(REMAPPING)
+        .entityType(AUTHORITY);
+    var migrationOperation2 = new NewMigrationOperation()
+        .operationType(REMAPPING)
+        .entityType(EntityType.INSTANCE);
+    var postResult = doPost(marcMigrationEndpoint(), migrationOperation1).andReturn();
+    var operationId1 = contentAsObj(postResult, MigrationOperation.class).getId();
+    awaitUntilAsserted(() ->
+        assertThat(databaseHelper.getOperation(TENANT_ID, operationId1).getStatus())
+            .isEqualTo(OperationStatusType.DATA_MAPPING_COMPLETED)
+    );
+    postResult = doPost(marcMigrationEndpoint(), migrationOperation2).andReturn();
+    var operationId2 = contentAsObj(postResult, MigrationOperation.class).getId();
+    awaitUntilAsserted(() ->
+        assertThat(databaseHelper.getOperation(TENANT_ID, operationId2).getStatus())
+            .isEqualTo(OperationStatusType.DATA_MAPPING_COMPLETED)
+    );
+    postResult = doPost(marcMigrationEndpoint(), migrationOperation1).andReturn();
+    var operationId3 = contentAsObj(postResult, MigrationOperation.class).getId();
+
+    var response = tryGet(marcMigrationEndpoint())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("totalRecords", is(3)))
+        .andExpect(jsonPath("migrationOperations", hasSize(3)))
+        .andExpect(jsonPath("migrationOperations[0].id", is(operationId3.toString())))
+        .andExpect(jsonPath("migrationOperations[0].entityType", is(AUTHORITY.getValue())))
+        .andExpect(jsonPath("migrationOperations[0].status",
+            oneOf(NEW.getValue(), DATA_MAPPING.getValue(), DATA_MAPPING_COMPLETED.getValue())))
+        .andExpect(jsonPath("migrationOperations[0].totalNumOfRecords", is(87)))
+        .andExpect(jsonPath("migrationOperations[0].mappedNumOfRecords", lessThanOrEqualTo(87)))
+        .andExpect(jsonPath("migrationOperations[1].id", is(operationId2.toString())))
+        .andExpect(jsonPath("migrationOperations[1].entityType", is(INSTANCE.getValue())))
+        .andExpect(jsonPath("migrationOperations[1].status", is(DATA_MAPPING_COMPLETED.getValue())))
+        .andExpect(jsonPath("migrationOperations[1].totalNumOfRecords", is(11)))
+        .andExpect(jsonPath("migrationOperations[1].mappedNumOfRecords", is(11)))
+        .andExpect(jsonPath("migrationOperations[2].id", is(operationId1.toString())))
+        .andExpect(jsonPath("migrationOperations[2].entityType", is(AUTHORITY.getValue())))
+        .andExpect(jsonPath("migrationOperations[2].status", is(DATA_MAPPING_COMPLETED.getValue())))
+        .andExpect(jsonPath("migrationOperations[2].totalNumOfRecords", is(87)))
+        .andExpect(jsonPath("migrationOperations[2].mappedNumOfRecords", is(87)))
+        .andReturn();
+
+    var dtoCollection = contentAsObj(response, MigrationOperationCollection.class);
+    assertThat(dtoCollection.getMigrationOperations())
+        .extracting(MigrationOperation::getStartTimeMapping)
+        .isSortedAccordingTo(Comparator.reverseOrder());
+
+    tryGet(marcMigrationEndpoint() + "?offset=1")
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("totalRecords", is(3)))
+        .andExpect(jsonPath("migrationOperations", hasSize(2)))
+        .andExpect(jsonPath("migrationOperations[0].id", is(operationId2.toString())))
+        .andExpect(jsonPath("migrationOperations[1].id", is(operationId1.toString())));
+
+    tryGet(marcMigrationEndpoint() + "?limit=2")
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("totalRecords", is(3)))
+        .andExpect(jsonPath("migrationOperations", hasSize(2)))
+        .andExpect(jsonPath("migrationOperations[0].id", is(operationId3.toString())))
+        .andExpect(jsonPath("migrationOperations[1].id", is(operationId2.toString())));
+
+    tryGet(marcMigrationEndpoint() + "?entityType=%s".formatted(AUTHORITY))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("totalRecords", is(2)))
+        .andExpect(jsonPath("migrationOperations", hasSize(2)))
+        .andExpect(jsonPath("migrationOperations[0].id", is(operationId3.toString())))
+        .andExpect(jsonPath("migrationOperations[1].id", is(operationId1.toString())));
+  }
+
+  @Test
+  void getMigrationCollection_negative_entityTypeIsUnexpected() throws Exception {
+    // Act & Assert
+    tryGet(marcMigrationEndpoint() + "?entityType=unexpected")
+        .andExpect(status().isBadRequest())
+        .andExpect(errorMessageMatches(containsString(
+            "Method parameter 'entityType': Failed to convert value of type 'java.lang.String' to required type"
+                + " 'org.folio.marc.migrations.domain.dto.EntityType'")))
+        .andExpect(errorTypeMatches(MethodArgumentTypeMismatchException.class));
   }
 
   @Test
@@ -345,8 +436,8 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
   void saveMigrationAuthority_positive() throws Exception {
     // Arrange
     var migrationOperation = new NewMigrationOperation()
-        .operationType(OperationType.REMAPPING)
-        .entityType(EntityType.AUTHORITY);
+        .operationType(REMAPPING)
+        .entityType(AUTHORITY);
 
     // Act & Assert
     var result = doPost(marcMigrationEndpoint(), migrationOperation)
@@ -392,7 +483,7 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
   void saveMigrationInstance_positive() throws Exception {
     // Arrange
     var migrationOperation = new NewMigrationOperation()
-        .operationType(OperationType.REMAPPING)
+        .operationType(REMAPPING)
         .entityType(EntityType.INSTANCE);
 
     // Act & Assert
@@ -445,8 +536,8 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
         .withBody("{ \"errorsNumber\": \"2\", \"errorRecordsFileName\": \"errorRecordsFileName\", "
             + "\"errorsFileName\": \"errorsFileName\" }")));
     var migrationOperation = new NewMigrationOperation()
-        .operationType(OperationType.REMAPPING)
-        .entityType(EntityType.AUTHORITY);
+        .operationType(REMAPPING)
+        .entityType(AUTHORITY);
 
     // Act & Assert
     var result = doPost(marcMigrationEndpoint(), migrationOperation)
@@ -499,7 +590,7 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
             .withBody("{ \"errorsNumber\": \"2\", \"errorRecordsFileName\": \"errorRecordsFileName\", "
                 + "\"errorsFileName\": \"errorsFileName\" }")));
     var migrationOperation = new NewMigrationOperation()
-        .operationType(OperationType.REMAPPING)
+        .operationType(REMAPPING)
         .entityType(EntityType.INSTANCE);
 
     // Act & Assert

--- a/src/test/java/org/folio/marc/migrations/controllers/MarcMigrationsControllerTest.java
+++ b/src/test/java/org/folio/marc/migrations/controllers/MarcMigrationsControllerTest.java
@@ -4,9 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.UUID;
 import org.folio.marc.migrations.controllers.delegates.MarcMigrationsService;
+import org.folio.marc.migrations.domain.dto.EntityType;
 import org.folio.marc.migrations.domain.dto.MigrationOperation;
+import org.folio.marc.migrations.domain.dto.MigrationOperationCollection;
 import org.folio.marc.migrations.domain.dto.NewMigrationOperation;
 import org.folio.marc.migrations.domain.dto.SaveMigrationOperation;
 import org.folio.spring.testing.type.UnitTest;
@@ -49,6 +52,22 @@ class MarcMigrationsControllerTest {
 
     // Act
     var response = migrationsController.getMarcMigrationById(operationId, "tenantId");
+
+    // Assert
+    assertEquals(HttpStatus.OK, response.getStatusCode());
+    assertEquals(result, response.getBody());
+  }
+
+  @Test
+  void getMarcMigrations_ReturnsOkResponse() {
+    // Arrange
+    MigrationOperationCollection result = new MigrationOperationCollection()
+        .migrationOperations(List.of(new MigrationOperation()))
+        .totalRecords(1);
+    when(migrationsService.getMarcMigrations(0, 100, EntityType.AUTHORITY)).thenReturn(result);
+
+    // Act
+    var response = migrationsController.getMarcMigrations(0, 100, EntityType.AUTHORITY);
 
     // Assert
     assertEquals(HttpStatus.OK, response.getStatusCode());

--- a/src/test/java/org/folio/marc/migrations/services/operations/OperationsServiceTest.java
+++ b/src/test/java/org/folio/marc/migrations/services/operations/OperationsServiceTest.java
@@ -4,9 +4,11 @@ import static org.folio.marc.migrations.domain.entities.types.EntityType.AUTHORI
 import static org.folio.marc.migrations.domain.entities.types.EntityType.INSTANCE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.folio.marc.migrations.domain.entities.Operation;
@@ -23,6 +25,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
@@ -81,5 +86,33 @@ class OperationsServiceTest {
 
     // Assert
     assertEquals(fetchedOperation, result);
+  }
+
+  @Test
+  void getOperations_ReturnsOperations() {
+    // Arrange
+    var expected = new PageImpl<>(List.of(new Operation()));
+    when(repository.findAll(any(Pageable.class))).thenReturn(expected);
+
+    // Act
+    var result = service.getOperations(0, 100, null);
+
+    // Assert
+    assertEquals(expected, result);
+    verify(repository).findAll(any(Pageable.class));
+  }
+
+  @Test
+  void getOperations_ReturnsOperationsForGivenEntityType() {
+    // Arrange
+    var expected = new PageImpl<>(List.of(new Operation()));
+    when(repository.findAll(any(Specification.class), any(Pageable.class))).thenReturn(expected);
+
+    // Act
+    var result = service.getOperations(0, 100, AUTHORITY);
+
+    // Assert
+    assertEquals(expected, result);
+    verify(repository).findAll(any(Specification.class), any(Pageable.class));
   }
 }

--- a/src/test/java/org/folio/support/IntegrationTestBase.java
+++ b/src/test/java/org/folio/support/IntegrationTestBase.java
@@ -19,6 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
 import lombok.SneakyThrows;
 import org.awaitility.core.ThrowingRunnable;
@@ -94,6 +95,7 @@ public class IntegrationTestBase {
   static void setUpClass(@Autowired MockMvc mockMvc, @Autowired DatabaseHelper databaseHelper) {
     IntegrationTestBase.mockMvc = mockMvc;
     IntegrationTestBase.databaseHelper = databaseHelper;
+    MAPPER.registerModule(new JavaTimeModule());
   }
 
   @SneakyThrows


### PR DESCRIPTION
### Purpose
_Add GET API to list all marc migration operations_

### Approach
- introduce new GET endpoint
- add paginations support
- add filtering by record type support
- make response sorted by created date desc

### Changes Checklist
- [x] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [x] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODMARCMIG-51](https://folio-org.atlassian.net/browse/MODMARCMIG-51)