### PR TITLE
fix(retry-marc-migration) Add ability to retry remapping/saving for DATA_MAPPING_COMPLETED job status.

### DIFF
--- a/src/main/java/org/folio/marc/migrations/config/SpringBatchConfig.java
+++ b/src/main/java/org/folio/marc/migrations/config/SpringBatchConfig.java
@@ -13,6 +13,7 @@ import org.folio.marc.migrations.services.batch.mapping.MappingRecordsWriter;
 import org.folio.marc.migrations.services.batch.saving.SavingRecordsChunkProcessor;
 import org.folio.marc.migrations.services.batch.saving.SavingRecordsStepListener;
 import org.folio.marc.migrations.services.batch.saving.SavingRecordsWriter;
+import org.folio.marc.migrations.services.batch.saving.SavingRetryRecordsChunkProcessor;
 import org.folio.marc.migrations.services.domain.DataSavingResult;
 import org.folio.marc.migrations.services.domain.MappingComposite;
 import org.folio.marc.migrations.services.domain.MappingResult;
@@ -207,7 +208,7 @@ public class SpringBatchConfig {
                                        PlatformTransactionManager transactionManager,
                                        @Qualifier("retryingSyncReader")
                                        ItemReader<OperationChunk> reader,
-                                       SavingRecordsChunkProcessor processor,
+                                       SavingRetryRecordsChunkProcessor processor,
                                        SavingRecordsWriter writer,
                                        SavingRecordsStepListener listener,
                                        @Qualifier("chunksProcessingExecutor") TaskExecutor executor,

--- a/src/main/java/org/folio/marc/migrations/controllers/delegates/MarcMigrationsService.java
+++ b/src/main/java/org/folio/marc/migrations/controllers/delegates/MarcMigrationsService.java
@@ -90,7 +90,8 @@ public class MarcMigrationsService {
     log.debug("retryMigrationSaveOperation::Retry saving migration operation by ID '{}'", operationId);
     var operation = operationsService.getOperation(operationId)
       .orElseThrow(() -> new NotFoundException(NOT_FOUND_MSG.formatted(operationId)));
-    if (operation.getStatus() != OperationStatusType.DATA_SAVING_FAILED) {
+    if (operation.getStatus() != OperationStatusType.DATA_SAVING_FAILED
+        && operation.getStatus() != OperationStatusType.DATA_MAPPING_COMPLETED) {
       throw ApiValidationException.notAllowedRetryForOperationStatus(operation.getStatus().name());
     }
     validateMigrationRetry(chunkIds);

--- a/src/main/java/org/folio/marc/migrations/services/batch/mapping/MappingRecordsChunkPreProcessor.java
+++ b/src/main/java/org/folio/marc/migrations/services/batch/mapping/MappingRecordsChunkPreProcessor.java
@@ -4,6 +4,7 @@ import static org.folio.marc.migrations.services.batch.support.JobConstants.OPER
 
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -46,6 +47,13 @@ public class MappingRecordsChunkPreProcessor implements ItemProcessor<OperationC
   @Override
   public MappingComposite<MarcRecord> process(OperationChunk chunk) {
     log.trace("process:: for operation {} chunk {}", chunk.getOperationId(), chunk.getId());
+
+    var records = (entityType == EntityType.AUTHORITY)
+        ? authorityJdbcService.getAuthoritiesChunk(chunk.getStartRecordId(), chunk.getEndRecordId()) :
+        instanceJdbcService.getInstancesChunk(chunk.getStartRecordId(), chunk.getEndRecordId());
+    log.debug("process:: retrieved {} records for operation {} chunk {}", records.size(), chunk.getOperationId(),
+        chunk.getId());
+
     ChunkStep chunkStep;
     if (!OperationStatusType.NEW.equals(chunk.getStatus())) {
       chunkStep = chunkStepJdbcService.getChunkStepByChunkIdAndOperationStep(chunk.getId(), OperationStep.DATA_MAPPING);
@@ -53,7 +61,7 @@ public class MappingRecordsChunkPreProcessor implements ItemProcessor<OperationC
         log.debug("process:: Updating existing chunk step for operation {} chunk {}", chunk.getOperationId(),
             chunk.getId());
         chunkStepJdbcService.updateChunkStep(chunkStep.getId(), StepStatus.IN_PROGRESS, Timestamp.from(Instant.now()));
-        reduceMappedNumOfRecords(chunk, chunkStep.getNumOfErrors());
+        reduceMappedNumOfRecords(chunk, chunkStep.getNumOfErrors(), records);
       } else {
         log.debug("process:: Creating new chunk step for operation {} chunk {}", chunk.getOperationId(), chunk.getId());
         chunkStep = createChunkStep(chunk);
@@ -63,12 +71,6 @@ public class MappingRecordsChunkPreProcessor implements ItemProcessor<OperationC
       chunkStep = createChunkStep(chunk);
     }
 
-    var records = (entityType == EntityType.AUTHORITY)
-        ? authorityJdbcService.getAuthoritiesChunk(chunk.getStartRecordId(), chunk.getEndRecordId()) :
-          instanceJdbcService.getInstancesChunk(chunk.getStartRecordId(), chunk.getEndRecordId());
-
-    log.debug("process:: retrieved {} records for operation {} chunk {}, step {}",
-      records.size(), chunk.getOperationId(), chunk.getId(), chunkStep.getId());
     if (records.size() != chunk.getNumOfRecords()) {
       log.warn("process:: Wrong number of records [{}] for operation {} chunk {}, step {}; record ids from {} to {},"
           + " expected - [{}].", records.size(), chunk.getOperationId(), chunk.getId(), chunkStep.getId(),
@@ -81,9 +83,11 @@ public class MappingRecordsChunkPreProcessor implements ItemProcessor<OperationC
     return new MappingComposite<>(mappingData, records);
   }
 
-  private void reduceMappedNumOfRecords(OperationChunk chunk, Integer numOfErrors) {
+  private void reduceMappedNumOfRecords(OperationChunk chunk, Integer numOfErrors,  List<MarcRecord> records) {
     var errorCount = numOfErrors != null ? numOfErrors : 0;
-    var reducedMappedNumOfRecords = chunk.getNumOfRecords() - errorCount;
+    var reducedMappedNumOfRecords = records.size() != chunk.getNumOfRecords()
+        ? records.size() - errorCount
+        : chunk.getNumOfRecords() - errorCount;
     if (reducedMappedNumOfRecords > 0) {
       operationJdbcService.updateOperationMappedNumber(chunk.getOperationId(), reducedMappedNumOfRecords);
     }

--- a/src/main/java/org/folio/marc/migrations/services/batch/mapping/MappingRecordsChunkPreProcessor.java
+++ b/src/main/java/org/folio/marc/migrations/services/batch/mapping/MappingRecordsChunkPreProcessor.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
+import org.apache.commons.collections4.CollectionUtils;
 import org.folio.marc.migrations.domain.entities.ChunkStep;
 import org.folio.marc.migrations.domain.entities.MarcRecord;
 import org.folio.marc.migrations.domain.entities.OperationChunk;
@@ -83,13 +84,13 @@ public class MappingRecordsChunkPreProcessor implements ItemProcessor<OperationC
     return new MappingComposite<>(mappingData, records);
   }
 
-  private void reduceMappedNumOfRecords(OperationChunk chunk, Integer numOfErrors,  List<MarcRecord> records) {
-    var errorCount = numOfErrors != null ? numOfErrors : 0;
-    var reducedMappedNumOfRecords = records.size() != chunk.getNumOfRecords()
-        ? records.size() - errorCount
-        : chunk.getNumOfRecords() - errorCount;
-    if (reducedMappedNumOfRecords > 0) {
-      operationJdbcService.updateOperationMappedNumber(chunk.getOperationId(), reducedMappedNumOfRecords);
+  private void reduceMappedNumOfRecords(OperationChunk chunk, Integer numOfErrors, List<MarcRecord> records) {
+    if (CollectionUtils.isNotEmpty(records)) {
+      var errorCount = numOfErrors != null ? numOfErrors : 0;
+      var reducedMappedNumOfRecords = records.size() - errorCount;
+      if (reducedMappedNumOfRecords > 0) {
+        operationJdbcService.updateOperationMappedNumber(chunk.getOperationId(), reducedMappedNumOfRecords);
+      }
     }
   }
 

--- a/src/main/java/org/folio/marc/migrations/services/batch/mapping/MappingRecordsChunkPreProcessor.java
+++ b/src/main/java/org/folio/marc/migrations/services/batch/mapping/MappingRecordsChunkPreProcessor.java
@@ -82,11 +82,10 @@ public class MappingRecordsChunkPreProcessor implements ItemProcessor<OperationC
   }
 
   private void reduceMappedNumOfRecords(OperationChunk chunk, Integer numOfErrors) {
-    if (numOfErrors > 0) {
-      var reducedMappedNumOfRecords = chunk.getNumOfRecords() - numOfErrors;
-      if (reducedMappedNumOfRecords > 0) {
-        operationJdbcService.updateOperationMappedNumber(chunk.getOperationId(), reducedMappedNumOfRecords);
-      }
+    var errorCount = numOfErrors != null ? numOfErrors : 0;
+    var reducedMappedNumOfRecords = chunk.getNumOfRecords() - errorCount;
+    if (reducedMappedNumOfRecords > 0) {
+      operationJdbcService.updateOperationMappedNumber(chunk.getOperationId(), reducedMappedNumOfRecords);
     }
   }
 

--- a/src/main/java/org/folio/marc/migrations/services/batch/saving/SavingRecordsChunkProcessor.java
+++ b/src/main/java/org/folio/marc/migrations/services/batch/saving/SavingRecordsChunkProcessor.java
@@ -2,21 +2,16 @@ package org.folio.marc.migrations.services.batch.saving;
 
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.extern.log4j.Log4j2;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.folio.marc.migrations.domain.entities.ChunkStep;
 import org.folio.marc.migrations.domain.entities.OperationChunk;
 import org.folio.marc.migrations.domain.entities.types.EntityType;
-import org.folio.marc.migrations.domain.entities.types.OperationStatusType;
 import org.folio.marc.migrations.domain.entities.types.OperationStep;
 import org.folio.marc.migrations.domain.entities.types.StepStatus;
 import org.folio.marc.migrations.services.BulkStorageService;
-import org.folio.marc.migrations.services.batch.support.FolioS3Service;
 import org.folio.marc.migrations.services.domain.DataSavingResult;
 import org.folio.marc.migrations.services.domain.RecordsSavingData;
 import org.folio.marc.migrations.services.jdbc.ChunkStepJdbcService;
@@ -41,73 +36,17 @@ public class SavingRecordsChunkProcessor implements ItemProcessor<OperationChunk
 
   private final BulkStorageService bulkStorageService;
   private final ChunkStepJdbcService chunkStepJdbcService;
-  private final FolioS3Service s3Service;
 
   @Override
   public DataSavingResult process(OperationChunk chunk) {
     log.trace("process:: for operation {} chunk {}", chunk.getOperationId(), chunk.getId());
-    var chunkStep = getOrCreateChunkStep(chunk);
-    int numOfRecords = chunk.getNumOfRecords();
-    if (OperationStatusType.DATA_SAVING_FAILED.equals(chunk.getStatus())
-        && chunkStep.getNumOfErrors() != null
-        && chunkStep.getNumOfErrors() > 0
-        && isChunkFileUpdated(chunk, chunkStep.getErrorChunkFileName())) {
-      numOfRecords = chunkStep.getNumOfErrors();
-    }
+
+    var chunkStep = createChunkStep(chunk);
     var recordsSavingData = new RecordsSavingData(chunk.getOperationId(), chunk.getId(), chunkStep.getId(),
-        numOfRecords);
+        chunk.getNumOfRecords());
+
     var saveResponse = bulkStorageService.saveEntities(chunk.getEntityChunkFileName(), entityType, publishEventsFlag);
     return new DataSavingResult(recordsSavingData, saveResponse);
-  }
-
-  private ChunkStep getOrCreateChunkStep(OperationChunk chunk) {
-    if (OperationStatusType.DATA_SAVING_FAILED.equals(chunk.getStatus())) {
-      var chunkStep = chunkStepJdbcService.getChunkStepByChunkIdAndOperationStep(chunk.getId(),
-          OperationStep.DATA_SAVING);
-      if (chunkStep != null) {
-        log.debug("getOrCreateChunkStep:: Updating existing chunk step for operation {} chunk {}",
-            chunk.getOperationId(), chunk.getId());
-        chunkStepJdbcService.updateChunkStep(chunkStep.getId(), StepStatus.IN_PROGRESS, Timestamp.from(Instant.now()));
-        return chunkStep;
-      }
-    }
-    log.debug("getOrCreateChunkStep:: Creating new chunk step for operation {} chunk {}", chunk.getOperationId(),
-        chunk.getId());
-    return createChunkStep(chunk);
-  }
-
-  private boolean isChunkFileUpdated(OperationChunk chunk, String errorChunkFileName) {
-    var entityChunkFileName = chunk.getEntityChunkFileName();
-
-    var entityLines = s3Service.readFile(entityChunkFileName);
-    log.debug("isChunkFileUpdated:: Read {} entity lines from chunk file: {}", entityLines.size(), entityChunkFileName);
-
-    var errorLines = s3Service.readFile(errorChunkFileName);
-    log.debug("isChunkFileUpdated:: Read {} error lines from chunk step file: {}", errorLines.size(),
-        errorChunkFileName);
-
-    if (CollectionUtils.isNotEmpty(entityLines) && CollectionUtils.isNotEmpty(errorLines)) {
-      var entityLinesForRetry = getEntityLinesForRetry(errorLines, entityLines);
-      if (CollectionUtils.isNotEmpty(entityLinesForRetry)) {
-        log.debug("isChunkFileUpdated:: Writing {} entity lines for retry to entity chunk file: {}",
-            entityLinesForRetry.size(), entityChunkFileName);
-        s3Service.writeFile(entityChunkFileName, entityLinesForRetry);
-        return true;
-      }
-      log.warn("isChunkFileUpdated:: No entity lines found for retry in chunk file: {}", entityChunkFileName);
-    }
-    return false;
-  }
-
-  private List<String> getEntityLinesForRetry(List<String> errorLines, List<String> entityLines) {
-    var errorRecordIds = errorLines.stream()
-      .map(errorLine -> StringUtils.substringBefore(errorLine, ','))
-      .toList();
-
-    return entityLines.stream()
-      .filter(str -> errorRecordIds.stream()
-        .anyMatch(str::contains))
-      .toList();
   }
 
   private ChunkStep createChunkStep(OperationChunk chunk) {

--- a/src/main/java/org/folio/marc/migrations/services/batch/saving/SavingRetryRecordsChunkProcessor.java
+++ b/src/main/java/org/folio/marc/migrations/services/batch/saving/SavingRetryRecordsChunkProcessor.java
@@ -1,0 +1,133 @@
+package org.folio.marc.migrations.services.batch.saving;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.folio.marc.migrations.domain.entities.ChunkStep;
+import org.folio.marc.migrations.domain.entities.OperationChunk;
+import org.folio.marc.migrations.domain.entities.types.EntityType;
+import org.folio.marc.migrations.domain.entities.types.OperationStatusType;
+import org.folio.marc.migrations.domain.entities.types.OperationStep;
+import org.folio.marc.migrations.domain.entities.types.StepStatus;
+import org.folio.marc.migrations.services.BulkStorageService;
+import org.folio.marc.migrations.services.batch.support.FolioS3Service;
+import org.folio.marc.migrations.services.domain.DataSavingResult;
+import org.folio.marc.migrations.services.domain.RecordsSavingData;
+import org.folio.marc.migrations.services.jdbc.ChunkStepJdbcService;
+import org.folio.marc.migrations.services.jdbc.OperationJdbcService;
+import org.springframework.batch.core.configuration.annotation.StepScope;
+import org.springframework.batch.item.ItemProcessor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Log4j2
+@Component()
+@StepScope
+@RequiredArgsConstructor
+public class SavingRetryRecordsChunkProcessor implements ItemProcessor<OperationChunk, DataSavingResult> {
+
+  @Setter
+  @Value("#{jobParameters['entityType']}")
+  private EntityType entityType;
+
+  @Setter
+  @Value("#{jobParameters['publishEventsFlag']}")
+  private Boolean publishEventsFlag;
+
+  private final BulkStorageService bulkStorageService;
+  private final ChunkStepJdbcService chunkStepJdbcService;
+  private final OperationJdbcService operationJdbcService;
+  private final FolioS3Service s3Service;
+
+  @Override
+  public DataSavingResult process(OperationChunk chunk) {
+    log.trace("process:: for operation {} chunk {}", chunk.getOperationId(), chunk.getId());
+    var chunkStep = getOrCreateChunkStep(chunk);
+    int numOfRecords = chunk.getNumOfRecords();
+    if (OperationStatusType.DATA_SAVING_FAILED.equals(chunk.getStatus())
+        && chunkStep.getNumOfErrors() != null
+        && chunkStep.getNumOfErrors() > 0
+        && isChunkFileUpdated(chunk, chunkStep.getErrorChunkFileName())) {
+      numOfRecords = chunkStep.getNumOfErrors();
+    } else {
+      // reduce the saved_num_of_records if saving is retry for all records in a chunk.
+      var numOfErrors = chunkStep.getNumOfErrors() != null ? chunkStep.getNumOfErrors() : 0;
+      var reducedSavedNumOfRecords = numOfRecords - numOfErrors;
+      operationJdbcService.updateOperationSavedNumber(chunk.getOperationId(), reducedSavedNumOfRecords);
+    }
+    var recordsSavingData = new RecordsSavingData(chunk.getOperationId(), chunk.getId(), chunkStep.getId(),
+        numOfRecords);
+    var saveResponse = bulkStorageService.saveEntities(chunk.getEntityChunkFileName(), entityType, publishEventsFlag);
+    return new DataSavingResult(recordsSavingData, saveResponse);
+  }
+
+  private ChunkStep getOrCreateChunkStep(OperationChunk chunk) {
+    var chunkStep = chunkStepJdbcService.getChunkStepByChunkIdAndOperationStep(chunk.getId(),
+        OperationStep.DATA_SAVING);
+    if (chunkStep != null) {
+      log.debug("getOrCreateChunkStep:: Updating existing chunk step for operation {} chunk {}", chunk.getOperationId(),
+          chunk.getId());
+      chunkStepJdbcService.updateChunkStep(chunkStep.getId(), StepStatus.IN_PROGRESS, Timestamp.from(Instant.now()));
+      return chunkStep;
+    }
+    log.debug("getOrCreateChunkStep:: Creating new chunk step for operation {} chunk {}", chunk.getOperationId(),
+        chunk.getId());
+    return createChunkStep(chunk);
+  }
+
+  private boolean isChunkFileUpdated(OperationChunk chunk, String errorChunkFileName) {
+    var entityChunkFileName = chunk.getEntityChunkFileName();
+
+    var entityLines = s3Service.readFile(entityChunkFileName);
+    log.debug("isChunkFileUpdated:: Read {} entity lines from chunk file: {}", entityLines.size(), entityChunkFileName);
+
+    var errorLines = s3Service.readFile(errorChunkFileName);
+    log.debug("isChunkFileUpdated:: Read {} error lines from chunk step file: {}", errorLines.size(),
+        errorChunkFileName);
+
+    if (CollectionUtils.isNotEmpty(entityLines) && CollectionUtils.isNotEmpty(errorLines)) {
+      var entityLinesForRetry = getEntityLinesForRetry(errorLines, entityLines);
+      if (CollectionUtils.isNotEmpty(entityLinesForRetry)) {
+        log.debug("isChunkFileUpdated:: Writing {} entity lines for retry to entity chunk file: {}",
+            entityLinesForRetry.size(),
+            entityChunkFileName);
+        s3Service.writeFile(entityChunkFileName, entityLinesForRetry);
+        return true;
+      }
+      log.warn("isChunkFileUpdated:: No entity lines found for retry in chunk file: {}", entityChunkFileName);
+    }
+    return false;
+  }
+
+  private List<String> getEntityLinesForRetry(List<String> errorLines, List<String> entityLines) {
+    var errorRecordIds = errorLines.stream()
+      .map(errorLine -> StringUtils.substringBefore(errorLine, ','))
+      .toList();
+
+    return entityLines.stream()
+      .filter(str -> errorRecordIds.stream()
+        .anyMatch(str::contains))
+      .toList();
+  }
+
+  private ChunkStep createChunkStep(OperationChunk chunk) {
+    var stepId = UUID.randomUUID();
+    var chunkStep = ChunkStep.builder()
+      .id(stepId)
+      .operationId(chunk.getOperationId())
+      .operationChunkId(chunk.getId())
+      .operationStep(OperationStep.DATA_SAVING)
+      .status(StepStatus.IN_PROGRESS)
+      .stepStartTime(Timestamp.from(Instant.now()))
+      .build();
+
+    chunkStepJdbcService.createChunkStep(chunkStep);
+    return chunkStep;
+  }
+}

--- a/src/main/java/org/folio/marc/migrations/services/jdbc/OperationJdbcService.java
+++ b/src/main/java/org/folio/marc/migrations/services/jdbc/OperationJdbcService.java
@@ -35,6 +35,12 @@ public class OperationJdbcService extends JdbcService {
     WHERE id = '%s';
     """;
 
+  private static final String UPDATE_OPERATION_SAVED_NUM = """
+    UPDATE %s.operation
+    SET saved_num_of_records = saved_num_of_records - %s
+    WHERE id = '%s';
+    """;
+
   private static final String GET_OPERATION = """
     SELECT *
     FROM %s.operation
@@ -85,6 +91,12 @@ public class OperationJdbcService extends JdbcService {
   public void updateOperationMappedNumber(UUID id, int recordsReduced) {
     log.info("updateOperationMappedNumber::Reduced mapped records by {} for operation {}", recordsReduced, id);
     var sql = UPDATE_OPERATION_MAPPED_NUM.formatted(getSchemaName(), recordsReduced, id);
+    jdbcTemplate.update(sql);
+  }
+
+  public void updateOperationSavedNumber(UUID id, int recordsReduced) {
+    log.info("updateOperationSavedNumber::Reduced saved records by {} for operation {}", recordsReduced, id);
+    var sql = UPDATE_OPERATION_SAVED_NUM.formatted(getSchemaName(), recordsReduced, id);
     jdbcTemplate.update(sql);
   }
 

--- a/src/main/java/org/folio/marc/migrations/services/jdbc/SpringBatchExecutionParamsJdbcService.java
+++ b/src/main/java/org/folio/marc/migrations/services/jdbc/SpringBatchExecutionParamsJdbcService.java
@@ -29,6 +29,12 @@ public class SpringBatchExecutionParamsJdbcService extends JdbcService {
     log.info("getBatchExecutionParam::Fetching '{}' parameter for operationId '{}'", parameterName, operationId);
     var schemaName = getSchemaName();
     String sql = GET_BATCH_EXECUTION_PARAM.formatted(schemaName, parameterName, schemaName, operationId);
-    return jdbcTemplate.queryForObject(sql, String.class);
+    var results = jdbcTemplate.query(sql, (rs, rowNum) -> rs.getString("parameter_value"));
+    if (results.isEmpty()) {
+      log.warn("getBatchExecutionParam::No result found for parameter '{}' and operationId '{}'", parameterName,
+          operationId);
+      return null;
+    }
+    return results.getFirst();
   }
 }

--- a/src/main/java/org/folio/marc/migrations/services/jdbc/SpringBatchExecutionParamsJdbcService.java
+++ b/src/main/java/org/folio/marc/migrations/services/jdbc/SpringBatchExecutionParamsJdbcService.java
@@ -13,12 +13,14 @@ public class SpringBatchExecutionParamsJdbcService extends JdbcService {
       SELECT parameter_value
       FROM %s.batch_job_execution_params
       WHERE parameter_name = '%s'
-        AND job_execution_id = (
-          SELECT MAX(job_execution_id)
+        AND parameter_value IS NOT NULL
+        AND job_execution_id IN (
+          SELECT job_execution_id
           FROM %s.batch_job_execution_params
           WHERE parameter_name = 'operationId'
             AND parameter_value = '%s'
-        );
+        )
+      LIMIT 1;
       """;
 
   public SpringBatchExecutionParamsJdbcService(JdbcTemplate jdbcTemplate, FolioExecutionContext context) {

--- a/src/test/java/org/folio/marc/migrations/controllers/MarcMigrationsControllerIT.java
+++ b/src/test/java/org/folio/marc/migrations/controllers/MarcMigrationsControllerIT.java
@@ -841,6 +841,67 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
       .andExpect(savedRecords(totalRecords)));
   }
 
+  @SneakyThrows
+  @ParameterizedTest
+  @MethodSource("provideEntityTypesAndChunkSizes")
+  void retryMarcMigrations_positive_retryMappingForCompletedChunk(EntityType entityType, int totalRecords,
+                                                                  int expectedChunkSize) {
+    // Arrange
+    var migrationOperation = new NewMigrationOperation().operationType(REMAPPING)
+        .entityType(entityType);
+
+    // Act & Assert
+    // create migration operation
+    var result = tryPost(marcMigrationEndpoint(), migrationOperation).andExpect(status().isCreated())
+        .andExpect(jsonPath("id", notNullValue(UUID.class)))
+        .andExpect(jsonPath("userId", is(USER_ID)))
+        .andExpect(jsonPath("operationType", is(REMAPPING.getValue())))
+        .andExpect(jsonPath("entityType", is(entityType.getValue())))
+        .andExpect(operationStatus(NEW))
+        .andExpect(totalRecords(totalRecords))
+        .andExpect(mappedRecords(0))
+        .andExpect(savedRecords(0))
+        .andReturn();
+    var operation = contentAsObj(result, MigrationOperation.class);
+    var operationId = operation.getId();
+
+    doGetUntilMatches(marcMigrationEndpoint(operationId), operationStatus(DATA_MAPPING_COMPLETED));
+    doGet(marcMigrationEndpoint(operationId)).andExpect(status().isOk())
+        .andExpect(mappedRecords(totalRecords));
+
+    var chunks = databaseHelper.getOperationChunks(TENANT_ID, operationId);
+    assertThat(chunks).hasSize(expectedChunkSize);
+
+    // retry migration operation for DATA_MAPPING_COMPLETED chunk
+    var retryResult = tryPost(retryMarcMigrationEndpoint(operationId), List.of(chunks.getFirst().getId()))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("id", notNullValue(UUID.class)))
+        .andExpect(jsonPath("userId", is(USER_ID)))
+        .andExpect(jsonPath("operationType", is(REMAPPING.getValue())))
+        .andExpect(jsonPath("entityType", is(entityType.getValue())))
+        .andExpect(operationStatus(DATA_MAPPING))
+        .andExpect(totalRecords(totalRecords))
+        .andExpect(mappedRecords(totalRecords))
+        .andExpect(savedRecords(0))
+        .andReturn();
+    var retryOperation = contentAsObj(retryResult, MigrationOperation.class);
+    var retryOperationId = retryOperation.getId();
+
+    doGetUntilMatches(marcMigrationEndpoint(retryOperationId), operationStatus(DATA_MAPPING_COMPLETED));
+    doGet(marcMigrationEndpoint(retryOperationId)).andExpect(status().isOk())
+        .andExpect(totalRecords(totalRecords))
+        .andExpect(mappedRecords(totalRecords))
+        .andExpect(savedRecords(0));
+
+    // save migration operation
+    var saveMigrationOperation = new SaveMigrationOperation().status(DATA_SAVING);
+    tryPut(marcMigrationEndpoint(operationId), saveMigrationOperation).andExpect(status().isNoContent());
+    awaitUntilAsserted(() -> doGet(marcMigrationEndpoint(operationId)).andExpect(operationStatus(DATA_SAVING_COMPLETED))
+        .andExpect(totalRecords(totalRecords))
+        .andExpect(mappedRecords(totalRecords))
+        .andExpect(savedRecords(totalRecords)));
+  }
+
   @Test
   void retryMarcMigrations_negative_emptyChunkIds() throws Exception {
     // Arrange
@@ -916,6 +977,90 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
       .andExpect(totalRecords(totalRecords))
       .andExpect(mappedRecords(totalRecords))
       .andExpect(savedRecords(totalRecords)));
+  }
+
+  @SneakyThrows
+  @ParameterizedTest
+  @MethodSource("provideEntityTypesData")
+  void retrySaveMarcMigrations_positive_retrySavingForAllRecordsInChunk(EntityType entityType, int totalRecords,
+                                        int expectedChunkSize, int savedRecords, String bulkUrl) {
+    // Arrange
+    var migrationOperation = new NewMigrationOperation().operationType(REMAPPING)
+        .entityType(entityType);
+
+    // Act & Assert
+    // create migration operation
+    var result = tryPost(marcMigrationEndpoint(), migrationOperation).andExpect(status().isCreated())
+        .andExpect(jsonPath("id", notNullValue(UUID.class)))
+        .andExpect(jsonPath("userId", is(USER_ID)))
+        .andExpect(jsonPath("operationType", is(REMAPPING.getValue())))
+        .andExpect(jsonPath("entityType", is(entityType.getValue())))
+        .andExpect(operationStatus(NEW))
+        .andExpect(totalRecords(totalRecords))
+        .andExpect(mappedRecords(0))
+        .andExpect(savedRecords(0))
+        .andReturn();
+    var operation = contentAsObj(result, MigrationOperation.class);
+    var operationId = operation.getId();
+
+    doGetUntilMatches(marcMigrationEndpoint(operationId), operationStatus(DATA_MAPPING_COMPLETED));
+    Mockito.reset(chunkStepJdbcService);
+    doGet(marcMigrationEndpoint(operationId)).andExpect(status().isOk())
+        .andExpect(mappedRecords(totalRecords));
+
+    var chunks = databaseHelper.getOperationChunks(TENANT_ID, operationId);
+    assertThat(chunks).hasSize(expectedChunkSize);
+
+    var errorChunk = chunks.getFirst();
+    var fileNames = s3Client.list("operation/" + operationId + "/" + errorChunk.getId() + "_entity");
+    var entityList = readFile(fileNames.getFirst());
+    var errorFile = writeToFile("test.txt", List.of(entityList.getFirst()));
+
+    var wireMock = okapi.wireMockServer();
+    var stub = wireMock.stubFor(post(urlPathMatching(bulkUrl)).withRequestBody(containing(errorChunk.getId()
+            .toString()))
+        .willReturn(ResponseDefinitionBuilder.responseDefinition()
+            .withHeader("Content-Type", "application/json;charset=UTF-8")
+            .withBody("{ \"errorsNumber\": \"1\", \"errorRecordsFileName\": \"errorRecordsFileName\", "
+                + "\"errorsFileName\": \"" + errorFile + "\" }")));
+
+    // save migration operation
+    var saveMigrationOperation = new SaveMigrationOperation().status(DATA_SAVING);
+    tryPut(marcMigrationEndpoint(operationId), saveMigrationOperation).andExpect(status().isNoContent());
+    awaitUntilAsserted(() -> doGet(marcMigrationEndpoint(operationId)).andExpect(operationStatus(DATA_SAVING_FAILED))
+        .andExpect(totalRecords(totalRecords))
+        .andExpect(mappedRecords(totalRecords))
+        .andExpect(savedRecords(savedRecords)));
+
+    wireMock.removeStubMapping(stub);
+
+    // retry remapping for DATA_SAVING_FAILED chunk
+    var retryResult = tryPost(retryMarcMigrationEndpoint(operationId), List.of(errorChunk.getId()))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("id", notNullValue(UUID.class)))
+        .andExpect(jsonPath("userId", is(USER_ID)))
+        .andExpect(jsonPath("operationType", is(REMAPPING.getValue())))
+        .andExpect(jsonPath("entityType", is(entityType.getValue())))
+        .andExpect(operationStatus(DATA_MAPPING))
+        .andExpect(totalRecords(totalRecords))
+        .andExpect(mappedRecords(totalRecords))
+        .andExpect(savedRecords(savedRecords))
+        .andReturn();
+    var retryOperation = contentAsObj(retryResult, MigrationOperation.class);
+    var retryOperationId = retryOperation.getId();
+
+    doGetUntilMatches(marcMigrationEndpoint(retryOperationId), operationStatus(DATA_MAPPING_COMPLETED));
+    doGet(marcMigrationEndpoint(retryOperationId)).andExpect(status().isOk())
+        .andExpect(totalRecords(totalRecords))
+        .andExpect(mappedRecords(totalRecords))
+        .andExpect(savedRecords(savedRecords));
+
+    // retry saving migration operation
+    tryPost(retrySaveMarcMigrationEndpoint(operationId), List.of(errorChunk.getId())).andExpect(status().isNoContent());
+    awaitUntilAsserted(() -> doGet(marcMigrationEndpoint(operationId)).andExpect(operationStatus(DATA_SAVING_COMPLETED))
+        .andExpect(totalRecords(totalRecords))
+        .andExpect(mappedRecords(totalRecords))
+        .andExpect(savedRecords(totalRecords)));
   }
 
   @SneakyThrows

--- a/src/test/java/org/folio/marc/migrations/controllers/delegates/MarcMigrationsServiceTest.java
+++ b/src/test/java/org/folio/marc/migrations/controllers/delegates/MarcMigrationsServiceTest.java
@@ -401,7 +401,7 @@ class MarcMigrationsServiceTest {
         () -> migrationsService.retryMigrationSaveOperation(operationId, chunkIds));
     assertThat(exception)
       .hasMessage(
-          "Not allowed retry action for operation with value 'DATA_MAPPING_FAILEDgit status' in field 'status'");
+          "Not allowed retry action for operation with value 'DATA_MAPPING_FAILED' in field 'status'");
     verifyNoInteractions(errorReportsService);
     verifyNoInteractions(operationErrorJdbcService);
     verifyNoInteractions(migrationOrchestrator);

--- a/src/test/java/org/folio/marc/migrations/controllers/delegates/MarcMigrationsServiceTest.java
+++ b/src/test/java/org/folio/marc/migrations/controllers/delegates/MarcMigrationsServiceTest.java
@@ -393,14 +393,15 @@ class MarcMigrationsServiceTest {
     var operationId = UUID.randomUUID();
     var chunkIds = List.of(UUID.randomUUID(), UUID.randomUUID());
     var operation = new Operation();
-    operation.setStatus(OperationStatusType.DATA_MAPPING_COMPLETED);
+    operation.setStatus(OperationStatusType.DATA_MAPPING_FAILED);
     when(operationsService.getOperation(operationId)).thenReturn(Optional.of(operation));
 
     // Act & Assert
     var exception = assertThrows(ApiValidationException.class,
         () -> migrationsService.retryMigrationSaveOperation(operationId, chunkIds));
     assertThat(exception)
-      .hasMessage("Not allowed retry action for operation with value 'DATA_MAPPING_COMPLETED' in field 'status'");
+      .hasMessage(
+          "Not allowed retry action for operation with value 'DATA_MAPPING_FAILEDgit status' in field 'status'");
     verifyNoInteractions(errorReportsService);
     verifyNoInteractions(operationErrorJdbcService);
     verifyNoInteractions(migrationOrchestrator);

--- a/src/test/java/org/folio/marc/migrations/services/batch/mapping/MappingRecordsChunkPreProcessorTest.java
+++ b/src/test/java/org/folio/marc/migrations/services/batch/mapping/MappingRecordsChunkPreProcessorTest.java
@@ -6,7 +6,6 @@ import static org.folio.marc.migrations.domain.entities.types.EntityType.INSTANC
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -159,7 +158,7 @@ class MappingRecordsChunkPreProcessorTest {
     verify(chunkStepJdbcService).updateChunkStep(eq(existingChunkStep.getId()), eq(StepStatus.IN_PROGRESS),
         timestampCaptor.capture());
     assertThat(timestampCaptor.getValue()).isNotNull();
-    verify(operationJdbcService).updateOperationMappedNumber(chunk.getOperationId(), 5);
+    verify(operationJdbcService).updateOperationMappedNumber(chunk.getOperationId(), marcRecords.size());
   }
 
   @Test
@@ -233,7 +232,6 @@ class MappingRecordsChunkPreProcessorTest {
         .thenReturn(existingChunkStep);
     when(authorityJdbcService.getAuthoritiesChunk(chunk.getStartRecordId(), chunk.getEndRecordId()))
         .thenReturn(marcRecords);
-    doNothing().when(operationJdbcService).updateOperationMappedNumber(chunk.getOperationId(), 2);
 
     processor.setEntityType(EntityType.AUTHORITY);
 

--- a/src/test/java/org/folio/marc/migrations/services/batch/mapping/MappingRecordsChunkPreProcessorTest.java
+++ b/src/test/java/org/folio/marc/migrations/services/batch/mapping/MappingRecordsChunkPreProcessorTest.java
@@ -3,8 +3,11 @@ package org.folio.marc.migrations.services.batch.mapping;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.marc.migrations.domain.entities.types.EntityType.AUTHORITY;
 import static org.folio.marc.migrations.domain.entities.types.EntityType.INSTANCE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -114,6 +117,93 @@ class MappingRecordsChunkPreProcessorTest {
     assert result != null;
     assertThat(result.records()).hasSize(marcRecords.size())
       .containsAll(marcRecords);
+  }
+
+  @Test
+  void process_UpdatesExistingChunkStepWithReduceMappedNumOfRecords() {
+    // Arrange
+    var chunk = OperationChunk.builder()
+      .id(UUID.randomUUID())
+      .operationId(UUID.randomUUID())
+      .startRecordId(UUID.randomUUID())
+      .endRecordId(UUID.randomUUID())
+      .numOfRecords(5)
+      .status(OperationStatusType.DATA_MAPPING)
+      .build();
+
+    var existingChunkStep = ChunkStep.builder()
+      .id(UUID.randomUUID())
+      .operationId(chunk.getOperationId())
+      .operationChunkId(chunk.getId())
+      .operationStep(OperationStep.DATA_MAPPING)
+      .status(StepStatus.IN_PROGRESS)
+      .build();
+
+    var marcRecords = List.of(new MarcRecord(null, null, null, null, null));
+
+    when(chunkStepJdbcService.getChunkStepByChunkIdAndOperationStep(chunk.getId(), OperationStep.DATA_MAPPING))
+      .thenReturn(existingChunkStep);
+    when(authorityJdbcService.getAuthoritiesChunk(chunk.getStartRecordId(), chunk.getEndRecordId()))
+        .thenReturn(marcRecords);
+
+    processor.setEntityType(EntityType.AUTHORITY);
+
+    // Act
+    var result = processor.process(chunk);
+
+    // Assert
+
+    assert result != null;
+    assertThat(result.records()).hasSize(marcRecords.size()).containsAll(marcRecords);
+    var timestampCaptor = ArgumentCaptor.forClass(Timestamp.class);
+    verify(chunkStepJdbcService).updateChunkStep(eq(existingChunkStep.getId()), eq(StepStatus.IN_PROGRESS),
+        timestampCaptor.capture());
+    assertThat(timestampCaptor.getValue()).isNotNull();
+    verify(operationJdbcService).updateOperationMappedNumber(chunk.getOperationId(), 5);
+  }
+
+  @Test
+  void process_UpdatesExistingChunkStepWithoutReduceMappedNumOfRecords() {
+    // Arrange
+    var chunk = OperationChunk.builder()
+      .id(UUID.randomUUID())
+      .operationId(UUID.randomUUID())
+      .startRecordId(UUID.randomUUID())
+      .endRecordId(UUID.randomUUID())
+      .numOfRecords(5)
+      .status(OperationStatusType.DATA_MAPPING)
+      .build();
+
+    var existingChunkStep = ChunkStep.builder()
+      .id(UUID.randomUUID())
+      .operationId(chunk.getOperationId())
+      .operationChunkId(chunk.getId())
+      .operationStep(OperationStep.DATA_MAPPING)
+      .status(StepStatus.IN_PROGRESS)
+      .numOfErrors(5)
+      .build();
+
+    var marcRecords = List.of(new MarcRecord(null, null, null, null, null));
+
+    when(chunkStepJdbcService.getChunkStepByChunkIdAndOperationStep(chunk.getId(), OperationStep.DATA_MAPPING))
+      .thenReturn(existingChunkStep);
+    when(authorityJdbcService.getAuthoritiesChunk(chunk.getStartRecordId(), chunk.getEndRecordId()))
+        .thenReturn(marcRecords);
+
+    processor.setEntityType(EntityType.AUTHORITY);
+
+    // Act
+    var result = processor.process(chunk);
+
+    // Assert
+
+    assert result != null;
+    assertThat(result.records()).hasSize(marcRecords.size()).containsAll(marcRecords);
+    var timestampCaptor = ArgumentCaptor.forClass(Timestamp.class);
+    verify(chunkStepJdbcService).updateChunkStep(eq(existingChunkStep.getId()), eq(StepStatus.IN_PROGRESS),
+        timestampCaptor.capture());
+    assertThat(timestampCaptor.getValue()).isNotNull();
+    verify(operationJdbcService, never()).updateOperationMappedNumber(any(), anyInt());
   }
 
   @Test

--- a/src/test/java/org/folio/marc/migrations/services/batch/saving/SavingRecordsChunkProcessorTest.java
+++ b/src/test/java/org/folio/marc/migrations/services/batch/saving/SavingRecordsChunkProcessorTest.java
@@ -5,15 +5,11 @@ import static org.folio.marc.migrations.domain.entities.types.EntityType.AUTHORI
 import static org.folio.marc.migrations.domain.entities.types.EntityType.INSTANCE;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.List;
 import java.util.UUID;
-import java.util.stream.Stream;
 import org.assertj.core.api.SoftAssertions;
 import org.folio.marc.migrations.client.BulkClient.BulkResponse;
 import org.folio.marc.migrations.domain.entities.ChunkStep;
@@ -23,16 +19,12 @@ import org.folio.marc.migrations.domain.entities.types.OperationStatusType;
 import org.folio.marc.migrations.domain.entities.types.OperationStep;
 import org.folio.marc.migrations.domain.entities.types.StepStatus;
 import org.folio.marc.migrations.services.BulkStorageService;
-import org.folio.marc.migrations.services.batch.support.FolioS3Service;
 import org.folio.marc.migrations.services.domain.RecordsSavingData;
 import org.folio.marc.migrations.services.jdbc.ChunkStepJdbcService;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -46,7 +38,6 @@ class SavingRecordsChunkProcessorTest {
 
   private @Mock BulkStorageService bulkStorageService;
   private @Mock ChunkStepJdbcService chunkStepJdbcService;
-  private @Mock FolioS3Service s3Service;
   private @InjectMocks SavingRecordsChunkProcessor processor;
 
   @BeforeEach
@@ -61,7 +52,7 @@ class SavingRecordsChunkProcessorTest {
   @Test
   void saveAuthority_positive() {
     int numOfRecords = 5;
-    var chunk = chunk(numOfRecords, AUTHORITY_OPERATION_ID, OperationStatusType.DATA_MAPPING);
+    var chunk = chunk(numOfRecords, AUTHORITY_OPERATION_ID);
     processor.setEntityType(AUTHORITY);
     processor.setPublishEventsFlag(Boolean.TRUE);
 
@@ -71,103 +62,11 @@ class SavingRecordsChunkProcessorTest {
   @Test
   void saveInstance_positive() {
     int numOfRecords = 5;
-    var chunk = chunk(numOfRecords, INSTANCE_OPERATION_ID, OperationStatusType.DATA_MAPPING);
+    var chunk = chunk(numOfRecords, INSTANCE_OPERATION_ID);
     processor.setEntityType(INSTANCE);
     processor.setPublishEventsFlag(Boolean.TRUE);
 
     save_positive(chunk, INSTANCE);
-  }
-
-  @ParameterizedTest
-  @MethodSource("chunkArguments")
-  void process_retry_shouldUpdateExistingChunkStep(UUID operationId, EntityType entityType) {
-    // Arrange
-    int numOfRecords = 5;
-    var chunk = chunk(numOfRecords, operationId, OperationStatusType.DATA_SAVING_FAILED);
-    var existingChunkStep = createChunkStep(chunk);
-    when(chunkStepJdbcService.getChunkStepByChunkIdAndOperationStep(chunk.getId(), OperationStep.DATA_SAVING))
-      .thenReturn(existingChunkStep);
-
-    var errorChunkFileName = existingChunkStep.getErrorChunkFileName();
-    var entityChunkFileName = chunk.getEntityChunkFileName();
-
-    // Mock S3 service behavior
-    when(s3Service.readFile(entityChunkFileName)).thenReturn(List.of("record1", "record2", "record3"));
-    when(s3Service.readFile(errorChunkFileName)).thenReturn(List.of("record1,error"));
-
-    processor.setEntityType(entityType);
-    processor.setPublishEventsFlag(Boolean.TRUE);
-
-    // Act
-    var result = processor.process(chunk);
-
-    // Assert
-    assertThat(result).isNotNull();
-    verify(chunkStepJdbcService).updateChunkStep(eq(existingChunkStep.getId()), eq(StepStatus.IN_PROGRESS),
-        any(Timestamp.class));
-    verify(s3Service).writeFile(entityChunkFileName, List.of("record1"));
-    verify(bulkStorageService).saveEntities(chunk.getEntityChunkFileName(), entityType, Boolean.TRUE);
-  }
-
-  @ParameterizedTest
-  @MethodSource("chunkArguments")
-  void process_retry_shouldCreateNewChunkStep_whenNoExistingChunkStep(UUID operationId, EntityType entityType) {
-    // Arrange
-    int numOfRecords = 5;
-    var chunk = chunk(numOfRecords, operationId, OperationStatusType.DATA_SAVING_FAILED);
-    when(chunkStepJdbcService.getChunkStepByChunkIdAndOperationStep(chunk.getId(),
-        OperationStep.DATA_SAVING)).thenReturn(null);
-    doNothing().when(chunkStepJdbcService)
-      .createChunkStep(any());
-    processor.setEntityType(entityType);
-    processor.setPublishEventsFlag(Boolean.TRUE);
-
-    // Act
-    var result = processor.process(chunk);
-
-    // Assert
-    assertThat(result).isNotNull();
-    verify(chunkStepJdbcService).createChunkStep(any());
-    verify(bulkStorageService).saveEntities(chunk.getEntityChunkFileName(), entityType, Boolean.TRUE);
-  }
-
-  @ParameterizedTest
-  @MethodSource("chunkArguments")
-  void process_shouldHandleNullResponseFromBulkStorageService(UUID operationId, EntityType entityType) {
-    // Arrange
-    int numOfRecords = 5;
-    var chunk = chunk(numOfRecords, operationId, OperationStatusType.DATA_SAVING_FAILED);
-    var existingChunkStep = createChunkStep(chunk);
-    when(chunkStepJdbcService.getChunkStepByChunkIdAndOperationStep(chunk.getId(), OperationStep.DATA_SAVING))
-      .thenReturn(existingChunkStep);
-
-    var errorChunkFileName = existingChunkStep.getErrorChunkFileName();
-    var entityChunkFileName = chunk.getEntityChunkFileName();
-
-    // Mock S3 service behavior
-    when(s3Service.readFile(entityChunkFileName)).thenReturn(List.of("record1", "record2", "record3"));
-    when(s3Service.readFile(errorChunkFileName)).thenReturn(List.of("record1,error"));
-    when(bulkStorageService.saveEntities(entityChunkFileName, entityType, Boolean.TRUE)).thenReturn(null);
-
-    processor.setEntityType(entityType);
-    processor.setPublishEventsFlag(Boolean.TRUE);
-
-    // Act
-    var result = processor.process(chunk);
-
-    // Assert
-    assertThat(result).isNotNull();
-    assertThat(result.saveResponse()).isNull();
-    var recordsSavingData = result.recordsSavingData();
-    assertThat(recordsSavingData).isNotNull();
-    assertThat(recordsSavingData.chunkId()).isEqualTo(chunk.getId());
-    assertThat(recordsSavingData.operationId()).isEqualTo(operationId);
-    assertThat(recordsSavingData.numberOfRecords()).isEqualTo(existingChunkStep.getNumOfErrors());
-
-    verify(chunkStepJdbcService).updateChunkStep(eq(existingChunkStep.getId()), eq(StepStatus.IN_PROGRESS),
-        any(Timestamp.class));
-    verify(s3Service).writeFile(entityChunkFileName, List.of("record1"));
-    verify(bulkStorageService).saveEntities(chunk.getEntityChunkFileName(), entityType, Boolean.TRUE);
   }
 
   void save_positive(OperationChunk chunk, EntityType entityType) {
@@ -211,7 +110,7 @@ class SavingRecordsChunkProcessorTest {
     softAssert.assertAll();
   }
 
-  private OperationChunk chunk(int numOfRecords, UUID operationId, OperationStatusType status) {
+  private OperationChunk chunk(int numOfRecords, UUID operationId) {
     return OperationChunk.builder()
         .id(UUID.randomUUID())
         .operationId(operationId)
@@ -221,27 +120,7 @@ class SavingRecordsChunkProcessorTest {
         .entityChunkFileName("entity" + numOfRecords)
         .marcChunkFileName("marc" + numOfRecords)
         .sourceChunkFileName("source" + numOfRecords)
-        .status(status)
+        .status(OperationStatusType.DATA_MAPPING)
         .build();
-  }
-
-  private ChunkStep createChunkStep(OperationChunk chunk) {
-    return ChunkStep.builder()
-      .id(UUID.randomUUID())
-      .operationId(chunk.getOperationId())
-      .operationChunkId(chunk.getId())
-      .operationStep(OperationStep.DATA_SAVING)
-      .status(StepStatus.FAILED)
-      .numOfErrors(1)
-      .entityErrorChunkFileName("entity_error")
-      .errorChunkFileName("error")
-      .stepStartTime(Timestamp.from(Instant.now()))
-      .build();
-  }
-
-  private static Stream<Arguments> chunkArguments() {
-    return Stream.of(
-        Arguments.of(AUTHORITY_OPERATION_ID, AUTHORITY),
-        Arguments.of(INSTANCE_OPERATION_ID, INSTANCE));
   }
 }

--- a/src/test/java/org/folio/marc/migrations/services/batch/saving/SavingRetryRecordsChunkProcessorTest.java
+++ b/src/test/java/org/folio/marc/migrations/services/batch/saving/SavingRetryRecordsChunkProcessorTest.java
@@ -1,0 +1,251 @@
+package org.folio.marc.migrations.services.batch.saving;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.marc.migrations.domain.entities.types.EntityType.AUTHORITY;
+import static org.folio.marc.migrations.domain.entities.types.EntityType.INSTANCE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+import org.assertj.core.api.SoftAssertions;
+import org.folio.marc.migrations.client.BulkClient;
+import org.folio.marc.migrations.domain.entities.ChunkStep;
+import org.folio.marc.migrations.domain.entities.OperationChunk;
+import org.folio.marc.migrations.domain.entities.types.EntityType;
+import org.folio.marc.migrations.domain.entities.types.OperationStatusType;
+import org.folio.marc.migrations.domain.entities.types.OperationStep;
+import org.folio.marc.migrations.domain.entities.types.StepStatus;
+import org.folio.marc.migrations.services.BulkStorageService;
+import org.folio.marc.migrations.services.batch.support.FolioS3Service;
+import org.folio.marc.migrations.services.domain.RecordsSavingData;
+import org.folio.marc.migrations.services.jdbc.ChunkStepJdbcService;
+import org.folio.marc.migrations.services.jdbc.OperationJdbcService;
+import org.folio.spring.testing.type.UnitTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class SavingRetryRecordsChunkProcessorTest {
+  private static final UUID AUTHORITY_OPERATION_ID = UUID.randomUUID();
+  private static final UUID INSTANCE_OPERATION_ID = UUID.randomUUID();
+
+  private @Mock BulkStorageService bulkStorageService;
+  private @Mock ChunkStepJdbcService chunkStepJdbcService;
+  private @Mock FolioS3Service s3Service;
+  private @Mock OperationJdbcService operationJdbcService;
+  private @InjectMocks SavingRetryRecordsChunkProcessor processor;
+
+  @BeforeEach
+  void setUpMocks() {
+    BulkClient.BulkResponse bulkResponse = new BulkClient.BulkResponse();
+    bulkResponse.setErrorsNumber(0);
+
+    when(bulkStorageService.saveEntities(any(), any(), eq(Boolean.TRUE)))
+        .thenReturn(bulkResponse);
+  }
+
+  @Test
+  void saveAuthority_positive() {
+    int numOfRecords = 5;
+    var chunk = chunk(numOfRecords, AUTHORITY_OPERATION_ID, OperationStatusType.DATA_MAPPING);
+    processor.setEntityType(AUTHORITY);
+    processor.setPublishEventsFlag(Boolean.TRUE);
+
+    save_positive(chunk, AUTHORITY);
+  }
+
+  @Test
+  void saveInstance_positive() {
+    int numOfRecords = 5;
+    var chunk = chunk(numOfRecords, INSTANCE_OPERATION_ID, OperationStatusType.DATA_MAPPING);
+    processor.setEntityType(INSTANCE);
+    processor.setPublishEventsFlag(Boolean.TRUE);
+
+    save_positive(chunk, INSTANCE);
+  }
+
+  @ParameterizedTest
+  @MethodSource("chunkArguments")
+  void process_retry_shouldUpdateExistingChunkStep(UUID operationId, EntityType entityType) {
+    // Arrange
+    int numOfRecords = 5;
+    var chunk = chunk(numOfRecords, operationId, OperationStatusType.DATA_SAVING_FAILED);
+    var existingChunkStep = createChunkStep(chunk);
+    when(chunkStepJdbcService.getChunkStepByChunkIdAndOperationStep(chunk.getId(), OperationStep.DATA_SAVING))
+        .thenReturn(existingChunkStep);
+
+    var errorChunkFileName = existingChunkStep.getErrorChunkFileName();
+    var entityChunkFileName = chunk.getEntityChunkFileName();
+
+    // Mock S3 service behavior
+    when(s3Service.readFile(entityChunkFileName)).thenReturn(List.of("record1", "record2", "record3"));
+    when(s3Service.readFile(errorChunkFileName)).thenReturn(List.of("record1,error"));
+
+    processor.setEntityType(entityType);
+    processor.setPublishEventsFlag(Boolean.TRUE);
+
+    // Act
+    var result = processor.process(chunk);
+
+    // Assert
+    assertThat(result).isNotNull();
+    verify(chunkStepJdbcService).updateChunkStep(eq(existingChunkStep.getId()), eq(StepStatus.IN_PROGRESS),
+        any(Timestamp.class));
+    verify(s3Service).writeFile(entityChunkFileName, List.of("record1"));
+    verify(bulkStorageService).saveEntities(chunk.getEntityChunkFileName(), entityType, Boolean.TRUE);
+  }
+
+  @ParameterizedTest
+  @MethodSource("chunkArguments")
+  void process_retry_shouldCreateNewChunkStep_whenNoExistingChunkStep(UUID operationId, EntityType entityType) {
+    // Arrange
+    int numOfRecords = 5;
+    var chunk = chunk(numOfRecords, operationId, OperationStatusType.DATA_SAVING_FAILED);
+    when(chunkStepJdbcService.getChunkStepByChunkIdAndOperationStep(chunk.getId(),
+        OperationStep.DATA_SAVING)).thenReturn(null);
+
+    doNothing().when(operationJdbcService).updateOperationSavedNumber(chunk.getOperationId(), numOfRecords);
+    doNothing().when(chunkStepJdbcService).createChunkStep(any());
+    processor.setEntityType(entityType);
+    processor.setPublishEventsFlag(Boolean.TRUE);
+
+    // Act
+    var result = processor.process(chunk);
+
+    // Assert
+    assertThat(result).isNotNull();
+    verify(chunkStepJdbcService).createChunkStep(any());
+    verify(bulkStorageService).saveEntities(chunk.getEntityChunkFileName(), entityType, Boolean.TRUE);
+  }
+
+  @ParameterizedTest
+  @MethodSource("chunkArguments")
+  void process_shouldHandleNullResponseFromBulkStorageService(UUID operationId, EntityType entityType) {
+    // Arrange
+    int numOfRecords = 5;
+    var chunk = chunk(numOfRecords, operationId, OperationStatusType.DATA_SAVING_FAILED);
+    var existingChunkStep = createChunkStep(chunk);
+    when(chunkStepJdbcService.getChunkStepByChunkIdAndOperationStep(chunk.getId(), OperationStep.DATA_SAVING))
+        .thenReturn(existingChunkStep);
+
+    var errorChunkFileName = existingChunkStep.getErrorChunkFileName();
+    var entityChunkFileName = chunk.getEntityChunkFileName();
+
+    // Mock S3 service behavior
+    when(s3Service.readFile(entityChunkFileName)).thenReturn(List.of("record1", "record2", "record3"));
+    when(s3Service.readFile(errorChunkFileName)).thenReturn(List.of("record1,error"));
+    when(bulkStorageService.saveEntities(entityChunkFileName, entityType, Boolean.TRUE)).thenReturn(null);
+
+    processor.setEntityType(entityType);
+    processor.setPublishEventsFlag(Boolean.TRUE);
+
+    // Act
+    var result = processor.process(chunk);
+
+    // Assert
+    assertThat(result).isNotNull();
+    assertThat(result.saveResponse()).isNull();
+    var recordsSavingData = result.recordsSavingData();
+    assertThat(recordsSavingData).isNotNull();
+    assertThat(recordsSavingData.chunkId()).isEqualTo(chunk.getId());
+    assertThat(recordsSavingData.operationId()).isEqualTo(operationId);
+    assertThat(recordsSavingData.numberOfRecords()).isEqualTo(existingChunkStep.getNumOfErrors());
+
+    verify(chunkStepJdbcService).updateChunkStep(eq(existingChunkStep.getId()), eq(StepStatus.IN_PROGRESS),
+        any(Timestamp.class));
+    verify(s3Service).writeFile(entityChunkFileName, List.of("record1"));
+    verify(bulkStorageService).saveEntities(chunk.getEntityChunkFileName(), entityType, Boolean.TRUE);
+  }
+
+  void save_positive(OperationChunk chunk, EntityType entityType) {
+    var actual = processor.process(chunk);
+    assertThat(actual).isNotNull();
+    assertThat(actual.saveResponse()).isNotNull();
+    assertThat(actual.saveResponse().getErrorsNumber()).isZero();
+
+    var stepCaptor = ArgumentCaptor.forClass(ChunkStep.class);
+    verify(chunkStepJdbcService).createChunkStep(stepCaptor.capture());
+    verify(bulkStorageService).saveEntities(chunk.getEntityChunkFileName(), entityType, Boolean.TRUE);
+    var step = stepCaptor.getValue();
+    var operationId = entityType == AUTHORITY ? AUTHORITY_OPERATION_ID : INSTANCE_OPERATION_ID;
+
+    assertRecordSavingData(actual.recordsSavingData(), chunk, operationId, step);
+    assertChunkStep(chunk, step);
+  }
+
+  private void assertRecordSavingData(RecordsSavingData recordsSavingData, OperationChunk chunk,
+                                      UUID operationId, ChunkStep step) {
+    var softAssert = new SoftAssertions();
+
+    softAssert.assertThat(recordsSavingData.chunkId()).isEqualTo(chunk.getId());
+    softAssert.assertThat(recordsSavingData.operationId()).isEqualTo(operationId);
+    softAssert.assertThat(recordsSavingData.numberOfRecords()).isEqualTo(chunk.getNumOfRecords());
+    softAssert.assertThat(recordsSavingData.stepId()).isEqualTo(step.getId());
+
+    softAssert.assertAll();
+  }
+
+  private void assertChunkStep(OperationChunk chunk, ChunkStep step) {
+    var softAssert = new SoftAssertions();
+
+    softAssert.assertThat(step.getId()).isNotNull();
+    softAssert.assertThat(step.getOperationId()).isEqualTo(chunk.getOperationId());
+    softAssert.assertThat(step.getOperationChunkId()).isEqualTo(chunk.getId());
+    softAssert.assertThat(step.getOperationStep()).isEqualTo(OperationStep.DATA_SAVING);
+    softAssert.assertThat(step.getStatus()).isEqualTo(StepStatus.IN_PROGRESS);
+    softAssert.assertThat(step.getStepStartTime()).isNotNull().isBefore(Instant.now());
+
+    softAssert.assertAll();
+  }
+
+  private OperationChunk chunk(int numOfRecords, UUID operationId, OperationStatusType status) {
+    return OperationChunk.builder()
+        .id(UUID.randomUUID())
+        .operationId(operationId)
+        .startRecordId(UUID.randomUUID())
+        .endRecordId(UUID.randomUUID())
+        .numOfRecords(numOfRecords)
+        .entityChunkFileName("entity" + numOfRecords)
+        .marcChunkFileName("marc" + numOfRecords)
+        .sourceChunkFileName("source" + numOfRecords)
+        .status(status)
+        .build();
+  }
+
+  private ChunkStep createChunkStep(OperationChunk chunk) {
+    return ChunkStep.builder()
+        .id(UUID.randomUUID())
+        .operationId(chunk.getOperationId())
+        .operationChunkId(chunk.getId())
+        .operationStep(OperationStep.DATA_SAVING)
+        .status(StepStatus.FAILED)
+        .numOfErrors(1)
+        .entityErrorChunkFileName("entity_error")
+        .errorChunkFileName("error")
+        .stepStartTime(Timestamp.from(Instant.now()))
+        .build();
+  }
+
+  private static Stream<Arguments> chunkArguments() {
+    return Stream.of(
+        Arguments.of(AUTHORITY_OPERATION_ID, AUTHORITY),
+        Arguments.of(INSTANCE_OPERATION_ID, INSTANCE));
+  }
+}
+

--- a/src/test/java/org/folio/marc/migrations/services/batch/saving/SavingRetryRecordsChunkProcessorTest.java
+++ b/src/test/java/org/folio/marc/migrations/services/batch/saving/SavingRetryRecordsChunkProcessorTest.java
@@ -120,7 +120,6 @@ class SavingRetryRecordsChunkProcessorTest {
     when(chunkStepJdbcService.getChunkStepByChunkIdAndOperationStep(chunk.getId(),
         OperationStep.DATA_SAVING)).thenReturn(null);
 
-    doNothing().when(operationJdbcService).updateOperationSavedNumber(chunk.getOperationId(), numOfRecords);
     doNothing().when(chunkStepJdbcService).createChunkStep(any());
     processor.setEntityType(entityType);
     processor.setPublishEventsFlag(Boolean.TRUE);

--- a/src/test/java/org/folio/marc/migrations/services/jdbc/OperationJdbcServiceTest.java
+++ b/src/test/java/org/folio/marc/migrations/services/jdbc/OperationJdbcServiceTest.java
@@ -77,4 +77,20 @@ class OperationJdbcServiceTest extends JdbcServiceTestBase {
     verify(jdbcTemplate).update(sqlCaptor.capture());
     assertThat(sqlCaptor.getValue()).contains(id.toString(), String.valueOf(recordsMapped));
   }
+
+  @Test
+  void updateOperationSavedNumber_positive() {
+    // Arrange
+    var id = UUID.randomUUID();
+    var recordsReduced = 10;
+
+    // Act
+    service.updateOperationSavedNumber(id, recordsReduced);
+
+    // Assert
+    var sqlCaptor = ArgumentCaptor.forClass(String.class);
+    verify(jdbcTemplate).update(sqlCaptor.capture());
+    assertThat(sqlCaptor.getValue())
+        .contains(id.toString(), String.valueOf(recordsReduced));
+  }
 }

--- a/src/test/java/org/folio/marc/migrations/services/jdbc/SpringBatchExecutionParamsJdbcServiceTest.java
+++ b/src/test/java/org/folio/marc/migrations/services/jdbc/SpringBatchExecutionParamsJdbcServiceTest.java
@@ -2,16 +2,17 @@ package org.folio.marc.migrations.services.jdbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Collections;
 import org.folio.spring.testing.type.UnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.RowMapper;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
@@ -25,7 +26,9 @@ class SpringBatchExecutionParamsJdbcServiceTest extends JdbcServiceTestBase {
     var parameterName = "testParam";
     var operationId = "testOperationId";
     var expectedValue = "testValue";
-    when(jdbcTemplate.queryForObject(any(String.class), eq(String.class))).thenReturn(expectedValue);
+
+    when(jdbcTemplate.query(any(String.class), any(RowMapper.class)))
+        .thenReturn(Collections.singletonList(expectedValue));
 
     // Act
     var result = service.getBatchExecutionParam(parameterName, operationId);
@@ -35,18 +38,18 @@ class SpringBatchExecutionParamsJdbcServiceTest extends JdbcServiceTestBase {
 
     // Verify SQL execution
     var sqlCaptor = ArgumentCaptor.forClass(String.class);
-    verify(jdbcTemplate).queryForObject(sqlCaptor.capture(), eq(String.class));
+    verify(jdbcTemplate).query(sqlCaptor.capture(), any(RowMapper.class));
     assertThat(sqlCaptor.getValue()).contains("SELECT parameter_value")
       .contains(parameterName)
       .contains(operationId);
   }
 
   @Test
-  void getBatchExecutionParam_shouldReturnNull_whenNoResultFound() {
+  void getBatchExecutionParam_negative() {
     // Arrange
     var parameterName = "testParam";
     var operationId = "testOperationId";
-    when(jdbcTemplate.queryForObject(any(String.class), eq(String.class))).thenReturn(null);
+    when(jdbcTemplate.query(any(String.class), any(RowMapper.class))).thenReturn(Collections.emptyList());
 
     // Act
     var result = service.getBatchExecutionParam(parameterName, operationId);
@@ -56,7 +59,7 @@ class SpringBatchExecutionParamsJdbcServiceTest extends JdbcServiceTestBase {
 
     // Verify SQL execution
     var sqlCaptor = ArgumentCaptor.forClass(String.class);
-    verify(jdbcTemplate).queryForObject(sqlCaptor.capture(), eq(String.class));
+    verify(jdbcTemplate).query(sqlCaptor.capture(), any(RowMapper.class));
     assertThat(sqlCaptor.getValue()).contains("SELECT parameter_value")
       .contains(parameterName)
       .contains(operationId);


### PR DESCRIPTION
### Purpose
Add ability to retry remapping/saving for `DATA_MAPPING_COMPLETED` job status.

If an optimistic locking issue occurs during the save process, we should be able to retry remapping all records in the chunk, and then retry saving all records in the chunk again.

### Approach
Added ability to retry remapping for `DATA_MAPPING_COMPLETED` job status.
Added ability to retry saving all records in chunk for `DATA_MAPPING_COMPLETED` job status
Moved logic from `SavingRecordsChunkProcessor` to `SavingRetryRecordsChunkProcessor` for the retry flow  and implemented a method to reduce `saved_num_of_records` if saving is retried for all records in a chunk.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

