### PR TITLE
feat(error-handling) Improve error handling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 * Create scheduled job to clean-up outdated migration jobs from database ([MODMARCMIG-53](https://folio-org.atlassian.net/browse/MODMARCMIG-53))
 * Create endpoints that will provide an error report ([MODMARCMIG-52](https://folio-org.atlassian.net/browse/MODMARCMIG-52))
 * Implement endpoint to execute only selected saving chunks ([MODMARCMIG-48](https://folio-org.atlassian.net/browse/MODMARCMIG-48))
+* Improve error handling ([https://folio-org.atlassian.net/browse/MODMARCMIG-65](MODMARCMIG-65))
 
 ### Bug fixes
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/src/main/java/org/folio/marc/migrations/config/SpringBatchConfig.java
+++ b/src/main/java/org/folio/marc/migrations/config/SpringBatchConfig.java
@@ -72,8 +72,8 @@ public class SpringBatchConfig {
     return operations;
   }
 
-  @Bean("remapAuthRecordsStep")
-  public Step remapAuthRecordsStep(JobRepository jobRepository,
+  @Bean("remapRecordsStep")
+  public Step remapRecordsStep(JobRepository jobRepository,
                                    PlatformTransactionManager transactionManager,
                                    @Qualifier("syncReader")
                                    ItemReader<OperationChunk> reader,
@@ -83,7 +83,7 @@ public class SpringBatchConfig {
                                    MappingRecordsFileUploadStepListener listener,
                                    @Qualifier("chunksProcessingExecutor") TaskExecutor executor,
                                    RepeatOperations customThrottler) {
-    return new StepBuilder("remapAuthRecords", jobRepository)
+    return new StepBuilder("remapRecords", jobRepository)
       .<OperationChunk, MappingComposite<MappingResult>>chunk(1, transactionManager)
       .reader(reader)
       .processor(processor)
@@ -96,15 +96,15 @@ public class SpringBatchConfig {
 
   @Bean("remappingJob")
   public Job remappingJob(JobRepository jobRepository,
-                          @Qualifier("remapAuthRecordsStep") Step remapAuthRecordsStep) {
+                          @Qualifier("remapRecordsStep") Step remapRecordsStep) {
     return new JobBuilder("remapping", jobRepository)
       .incrementer(new RunIdIncrementer())
-      .start(remapAuthRecordsStep)
+      .start(remapRecordsStep)
       .build();
   }
 
-  @Bean(name = "remapSaveAuthRecordsStep")
-  public Step remapSaveAuthRecordsStep(JobRepository jobRepository,
+  @Bean(name = "remapSaveRecordsStep")
+  public Step remapSaveRecordsStep(JobRepository jobRepository,
                                        PlatformTransactionManager transactionManager,
                                        @Qualifier("syncReader")
                                        ItemReader<OperationChunk> reader,
@@ -113,7 +113,7 @@ public class SpringBatchConfig {
                                        SavingRecordsStepListener listener,
                                        @Qualifier("chunksProcessingExecutor") TaskExecutor executor,
                                        RepeatOperations customThrottler) {
-    return new StepBuilder("remapSaveAuthRecords", jobRepository)
+    return new StepBuilder("remapSaveRecords", jobRepository)
         .<OperationChunk, DataSavingResult>chunk(1, transactionManager)
         .reader(reader)
         .processor(processor)
@@ -126,10 +126,10 @@ public class SpringBatchConfig {
 
   @Bean("remappingSaveJob")
   public Job remappingSaveJob(JobRepository jobRepository,
-                              @Qualifier("remapSaveAuthRecordsStep") Step remapAuthRecordsStep) {
+                              @Qualifier("remapSaveRecordsStep") Step remapRecordsStep) {
     return new JobBuilder("remappingSave", jobRepository)
         .incrementer(new RunIdIncrementer())
-        .start(remapAuthRecordsStep)
+        .start(remapRecordsStep)
         .build();
   }
 
@@ -165,25 +165,25 @@ public class SpringBatchConfig {
 
   @Bean("remappingRetryJob")
   public Job remappingRetryJob(JobRepository jobRepository,
-                               @Qualifier("remapAuthRetryRecordsStep") Step remapAuthRetryRecordsStep) {
+                               @Qualifier("remapRetryRecordsStep") Step remapRetryRecordsStep) {
     return new JobBuilder("remappingRetry", jobRepository)
         .incrementer(new RunIdIncrementer())
-        .start(remapAuthRetryRecordsStep)
+        .start(remapRetryRecordsStep)
         .build();
   }
 
-  @Bean("remapAuthRetryRecordsStep")
-  public Step remapAuthRetryRecordsStep(JobRepository jobRepository,
-                                        PlatformTransactionManager transactionManager,
-                                        @Qualifier("retryingSyncReader")
+  @Bean("remapRetryRecordsStep")
+  public Step remapRetryRecordsStep(JobRepository jobRepository,
+                                    PlatformTransactionManager transactionManager,
+                                    @Qualifier("retryingSyncReader")
                                         ItemReader<OperationChunk> reader,
-                                        @Qualifier("remappingStepProcessor")
+                                    @Qualifier("remappingStepProcessor")
                                         ItemProcessor<OperationChunk, MappingComposite<MappingResult>> processor,
-                                        MappingRecordsWriter writer,
-                                        MappingRecordsFileUploadStepListener listener,
-                                        @Qualifier("chunksProcessingExecutor") TaskExecutor executor,
-                                        RepeatOperations customThrottler) {
-    return new StepBuilder("remapAuthRetryRecords", jobRepository)
+                                    MappingRecordsWriter writer,
+                                    MappingRecordsFileUploadStepListener listener,
+                                    @Qualifier("chunksProcessingExecutor") TaskExecutor executor,
+                                    RepeatOperations customThrottler) {
+    return new StepBuilder("remapRetryRecords", jobRepository)
         .<OperationChunk, MappingComposite<MappingResult>>chunk(1, transactionManager)
         .reader(reader)
         .processor(processor)

--- a/src/main/java/org/folio/marc/migrations/domain/entities/types/ErrorReportStatus.java
+++ b/src/main/java/org/folio/marc/migrations/domain/entities/types/ErrorReportStatus.java
@@ -1,6 +1,6 @@
 package org.folio.marc.migrations.domain.entities.types;
 
 public enum ErrorReportStatus {
-  NOT_STARTED, IN_PROGRESS, COMPLETED
+  NOT_STARTED, IN_PROGRESS, COMPLETED, ERROR
 }
 

--- a/src/main/java/org/folio/marc/migrations/services/batch/saving/SavingRetryRecordsChunkProcessor.java
+++ b/src/main/java/org/folio/marc/migrations/services/batch/saving/SavingRetryRecordsChunkProcessor.java
@@ -59,6 +59,7 @@ public class SavingRetryRecordsChunkProcessor implements ItemProcessor<Operation
       if (OperationStatusType.DATA_SAVING_FAILED.equals(chunk.getStatus())
           && chunkStep.getNumOfErrors() != null
           && chunkStep.getNumOfErrors() > 0
+          && StringUtils.isNotEmpty(chunkStep.getErrorChunkFileName())
           && isChunkFileUpdated(chunk, chunkStep.getErrorChunkFileName())) {
         numOfRecords = chunkStep.getNumOfErrors();
       } else {

--- a/src/main/java/org/folio/marc/migrations/services/operations/OperationErrorReportService.java
+++ b/src/main/java/org/folio/marc/migrations/services/operations/OperationErrorReportService.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CompletableFuture;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.folio.marc.migrations.domain.entities.ChunkStep;
 import org.folio.marc.migrations.domain.entities.Operation;
 import org.folio.marc.migrations.domain.entities.OperationError;
 import org.folio.marc.migrations.domain.entities.OperationErrorReport;
@@ -20,6 +21,7 @@ import org.folio.marc.migrations.services.batch.support.FolioS3Service;
 import org.folio.marc.migrations.services.jdbc.ChunkStepJdbcService;
 import org.folio.marc.migrations.services.jdbc.OperationErrorJdbcService;
 import org.folio.spring.data.OffsetRequest;
+import org.folio.util.UuidUtil;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 
@@ -27,7 +29,10 @@ import org.springframework.stereotype.Service;
 @Service
 public class OperationErrorReportService {
 
-  public static final String UNKNOWN_RECORD_ID = "<unknown>";
+  private static final String UNKNOWN_RECORD_ID = "<unknown>";
+  private static final String ERROR_FILE_NOT_FOUND = "Error file not found for chunk";
+  private static final String ERROR_PROCESSING_MESSAGE = "Error while processing error report for chunk step ";
+
   private final FolioS3Service s3Service;
   private final ChunkStepJdbcService chunkStepJdbcService;
   private final OperationErrorJdbcService operationErrorJdbcService;
@@ -64,55 +69,100 @@ public class OperationErrorReportService {
 
   public CompletableFuture<Void> initiateErrorReport(@NonNull Operation operation, String tenantId) {
     log.info("initiateErrorReport::Initiating error report for operation: {}", operation.getId());
-    updateErrorReportStatus(operation.getId(), ErrorReportStatus.IN_PROGRESS);
+    try {
+      updateErrorReportStatus(operation.getId(), ErrorReportStatus.IN_PROGRESS);
 
-    if (operation.getStatus() == OperationStatusType.DATA_MAPPING_COMPLETED
-        || operation.getStatus() == OperationStatusType.DATA_SAVING_COMPLETED) {
-      updateErrorReportStatus(operation.getId(), ErrorReportStatus.COMPLETED);
-      return CompletableFuture.completedFuture(null);
-    }
+      if (isOperationCompleted(operation)) {
+        updateErrorReportStatus(operation.getId(), ErrorReportStatus.COMPLETED);
+        return CompletableFuture.completedFuture(null);
+      }
 
-    var failedChunks = chunkStepJdbcService.getChunkStepsByOperationIdAndStatus(operation.getId(), StepStatus.FAILED);
-    if (failedChunks.isEmpty()) {
-      log.warn("initiateErrorReport::No failed chunks found for operation: {}", operation.getId());
-      updateErrorReportStatus(operation.getId(), ErrorReportStatus.COMPLETED);
-      return CompletableFuture.completedFuture(null);
-    }
-    // Process each failed chunk in parallel
-    List<CompletableFuture<Void>> futures = failedChunks.stream()
-      .map(chunkStep -> CompletableFuture.runAsync(() -> tenantContextRunner.runInContext(tenantId, () -> {
-        var errorFileLines = s3Service.readFile(chunkStep.getErrorChunkFileName());
-        if (CollectionUtils.isEmpty(errorFileLines)) {
-          log.warn("initiateErrorReport::No error file lines found for chunk step: {}", chunkStep.getId());
-          return;
-        }
-        List<OperationError> operationErrors = new ArrayList<>();
-        for (var errorFileLine : errorFileLines) {
-          String errorMessage = errorFileLine;
-          var recordId = StringUtils.substringBefore(errorFileLine, ',');
-          if (StringUtils.isBlank(recordId)) {
-            recordId = UNKNOWN_RECORD_ID;
+      var failedChunks = chunkStepJdbcService.getChunkStepsByOperationIdAndStatus(operation.getId(), StepStatus.FAILED);
+      if (failedChunks.isEmpty()) {
+        log.warn("initiateErrorReport::No failed chunks found for operation: {}", operation.getId());
+        updateErrorReportStatus(operation.getId(), ErrorReportStatus.COMPLETED);
+        return CompletableFuture.completedFuture(null);
+      }
+      // Process each failed chunk in parallel
+      List<CompletableFuture<Void>> futures = failedChunks.stream()
+        .map(chunkStep -> CompletableFuture.runAsync(() -> tenantContextRunner.runInContext(tenantId, () -> {
+          List<OperationError> operationErrors = new ArrayList<>();
+          if (StringUtils.isEmpty(chunkStep.getErrorChunkFileName())) {
+            operationErrors.add(createErrorForMissingFile(chunkStep, operation));
           } else {
-            errorMessage = StringUtils.substringAfter(errorFileLine, ',');
+            var errorFileLines = s3Service.readFile(chunkStep.getErrorChunkFileName());
+            if (CollectionUtils.isEmpty(errorFileLines)) {
+              log.warn("initiateErrorReport::No error file lines found for chunk step: {}", chunkStep.getId());
+              return;
+            }
+            errorFileLines.forEach(line ->
+                operationErrors.add(createOperationErrorFromLine(line, chunkStep, operation)));
           }
-          var operationError = new OperationError();
-          operationError.setId(UUID.randomUUID());
-          operationError.setReportId(operation.getId());
-          operationError.setChunkId(chunkStep.getOperationChunkId());
-          operationError.setOperationStep(chunkStep.getOperationStep());
-          operationError.setChunkStatus(chunkStep.getStatus());
-          operationError.setRecordId(recordId);
-          operationError.setErrorMessage(errorMessage);
-          operationErrors.add(operationError);
-        }
-        operationErrorJdbcService.saveOperationErrors(operationErrors, tenantId);
-      })))
-      .toList();
+          operationErrorJdbcService.saveOperationErrors(operationErrors, tenantId);
+        }))
+          .handle((result, ex) -> {
+            if (ex != null) {
+              log.error("initiateErrorReport::{}{}: {}", ERROR_PROCESSING_MESSAGE, chunkStep.getId(), ex.getMessage());
+              throw new IllegalStateException(ERROR_PROCESSING_MESSAGE + chunkStep.getId(), ex);
+            }
+            return result;
+          }))
+        .toList();
 
-    // Wait for all futures to complete and then update the status
-    return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
-      .thenAccept(unused -> tenantContextRunner.runInContext(tenantId,
-        () -> updateErrorReportStatus(operation.getId(), ErrorReportStatus.COMPLETED)));
+      // Wait for all futures to complete and then update the status
+      return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+        .thenAccept(unused -> tenantContextRunner.runInContext(tenantId,
+            () -> updateErrorReportStatus(operation.getId(), ErrorReportStatus.COMPLETED)))
+        .exceptionally(e -> {
+          handleProcessingError(operation, e);
+          return null;
+        });
+    } catch (Exception e) {
+      handleProcessingError(operation, e);
+      return CompletableFuture.failedFuture(e);
+    }
+  }
+
+  private boolean isOperationCompleted(Operation operation) {
+    return operation.getStatus() == OperationStatusType.DATA_MAPPING_COMPLETED
+        || operation.getStatus() == OperationStatusType.DATA_SAVING_COMPLETED;
+  }
+
+  private void handleProcessingError(Operation operation, Throwable e) {
+    log.error("initiateErrorReport::Error occurred while processing error report for operation: {}",
+        operation.getId(), e);
+    updateErrorReportStatus(operation.getId(), ErrorReportStatus.ERROR);
+  }
+
+  private OperationError createErrorForMissingFile(ChunkStep chunkStep, Operation operation) {
+    var error = new OperationError();
+    error.setId(UUID.randomUUID());
+    error.setReportId(operation.getId());
+    error.setChunkId(chunkStep.getOperationChunkId());
+    error.setOperationStep(chunkStep.getOperationStep());
+    error.setChunkStatus(chunkStep.getStatus());
+    error.setRecordId(UNKNOWN_RECORD_ID);
+    error.setErrorMessage(ERROR_FILE_NOT_FOUND);
+    return error;
+  }
+
+  private OperationError createOperationErrorFromLine(String errorLine, ChunkStep chunkStep, Operation operation) {
+    var errorMessage = errorLine;
+    var recordId = StringUtils.substringBefore(errorLine, ',');
+    if (StringUtils.isBlank(recordId) || !UuidUtil.isUuid(recordId)) {
+      recordId = UNKNOWN_RECORD_ID;
+    } else {
+      errorMessage = StringUtils.substringAfter(errorLine, ',');
+    }
+    var error = new OperationError();
+    error.setId(UUID.randomUUID());
+    error.setReportId(operation.getId());
+    error.setChunkId(chunkStep.getOperationChunkId());
+    error.setOperationStep(chunkStep.getOperationStep());
+    error.setChunkStatus(chunkStep.getStatus());
+    error.setRecordId(recordId);
+    error.setErrorMessage(errorMessage);
+    return error;
   }
 
   public Optional<OperationErrorReport> getErrorReport(UUID operationId) {

--- a/src/main/resources/db/changelog/changelog-master.xml
+++ b/src/main/resources/db/changelog/changelog-master.xml
@@ -11,4 +11,5 @@
   <include file="/changes/v2.1/add_cascade_deletes.xml" relativeToChangelogFile="true"/>
   <include file="/changes/v2.1/create_operation_error.xml" relativeToChangelogFile="true"/>
   <include file="/changes/v2.1/change_column_type.xml" relativeToChangelogFile="true"/>
+  <include file="/changes/v2.1/add_operation_error_status.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v2.1/add_operation_error_status.xml
+++ b/src/main/resources/db/changelog/changes/v2.1/add_operation_error_status.xml
@@ -1,0 +1,21 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+  <changeSet id="MODMARCMIG-65@@add:type:error_report_status" author="svitlana_kovalova">
+    <preConditions onFail="MARK_RAN">
+      <sqlCheck expectedResult="1">
+        SELECT count(*)
+        FROM pg_type t
+        JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+        WHERE t.typname = 'error_report_status'
+        AND n.nspname = '${database.defaultSchemaName}';
+      </sqlCheck>
+    </preConditions>
+    <comment>Add 'ERROR' status to error_report_status enum</comment>
+    <sql>ALTER TYPE error_report_status ADD VALUE 'ERROR'</sql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v2.1/add_operation_error_status.xml
+++ b/src/main/resources/db/changelog/changes/v2.1/add_operation_error_status.xml
@@ -7,23 +7,11 @@
   <changeSet id="MODMARCMIG-65@@add:type:error_report_status" author="svitlana_kovalova">
     <preConditions onFail="MARK_RAN">
       <sqlCheck expectedResult="1">
-        WITH enum_type_exists AS (
-          SELECT 1
-          FROM pg_type t
-          JOIN pg_namespace n ON n.oid = t.typnamespace
-          WHERE t.typname = 'error_report_status'
-            AND n.nspname = '${database.defaultSchemaName}'
-        )
-        SELECT CASE
-          WHEN EXISTS (SELECT 1 FROM enum_type_exists)
-            AND NOT EXISTS (
-              SELECT 1
-              FROM unnest(enum_range(NULL::error_report_status)) AS e(value)
-              WHERE value = 'ERROR'
-            )
-          THEN 1
-          ELSE 0
-        END;
+        SELECT count(*)
+        FROM pg_type t
+        JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+        WHERE t.typname = 'error_report_status'
+        AND n.nspname = '${database.defaultSchemaName}';
       </sqlCheck>
     </preConditions>
 

--- a/src/main/resources/db/changelog/changes/v2.1/add_operation_error_status.xml
+++ b/src/main/resources/db/changelog/changes/v2.1/add_operation_error_status.xml
@@ -7,14 +7,27 @@
   <changeSet id="MODMARCMIG-65@@add:type:error_report_status" author="svitlana_kovalova">
     <preConditions onFail="MARK_RAN">
       <sqlCheck expectedResult="1">
-        SELECT count(*)
-        FROM pg_type t
-        JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
-        WHERE t.typname = 'error_report_status'
-        AND n.nspname = '${database.defaultSchemaName}';
+        WITH enum_type_exists AS (
+          SELECT 1
+          FROM pg_type t
+          JOIN pg_namespace n ON n.oid = t.typnamespace
+          WHERE t.typname = 'error_report_status'
+            AND n.nspname = '${database.defaultSchemaName}'
+        )
+        SELECT CASE
+          WHEN EXISTS (SELECT 1 FROM enum_type_exists)
+            AND NOT EXISTS (
+              SELECT 1
+              FROM unnest(enum_range(NULL::error_report_status)) AS e(value)
+              WHERE value = 'ERROR'
+            )
+          THEN 1
+          ELSE 0
+        END;
       </sqlCheck>
     </preConditions>
-    <comment>Add 'ERROR' status to error_report_status enum</comment>
+
+    <comment>Add 'ERROR' value to error_report_status enum if it doesn't already exist</comment>
     <sql>ALTER TYPE error_report_status ADD VALUE 'ERROR'</sql>
   </changeSet>
 

--- a/src/main/resources/swagger.api/marc-migrations.yaml
+++ b/src/main/resources/swagger.api/marc-migrations.yaml
@@ -661,6 +661,7 @@ components:
             - not_started
             - in_progress
             - completed
+            - error
 
     MigrationOperationCollection:
       description: Collection of MARC migration operations with pagination information.

--- a/src/test/java/org/folio/marc/migrations/controllers/MarcMigrationsControllerIT.java
+++ b/src/test/java/org/folio/marc/migrations/controllers/MarcMigrationsControllerIT.java
@@ -74,7 +74,7 @@ import org.folio.spring.exception.NotFoundException;
 import org.folio.spring.testing.extension.DatabaseCleanup;
 import org.folio.spring.testing.type.IntegrationTest;
 import org.folio.support.IntegrationTestBase;
-import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -102,8 +102,8 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
     setUpTenant();
   }
 
-  @AfterAll
-  static void afterAll() throws IOException {
+  @AfterEach
+  void afterEach() throws IOException {
     FileUtils.deleteDirectory(new File("test"));
   }
 

--- a/src/test/java/org/folio/marc/migrations/controllers/MarcMigrationsControllerIT.java
+++ b/src/test/java/org/folio/marc/migrations/controllers/MarcMigrationsControllerIT.java
@@ -91,6 +91,7 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 class MarcMigrationsControllerIT extends IntegrationTestBase {
 
   private static final String OPERATION_PATH = "mod-marc-migrations/operation/%s/";
+  private static final String UNKNOWN_RECORD_ID = "<unknown>";
 
   private @MockitoSpyBean FolioS3Client s3Client;
   private @MockitoSpyBean ChunkStepJdbcService chunkStepJdbcService;
@@ -705,56 +706,92 @@ class MarcMigrationsControllerIT extends IntegrationTestBase {
   }
 
   @Test
-  void createErrorReport_positive_haveErrors() throws Exception {
+  void createErrorReport_positive_haveErrors_without_id() throws Exception {
     // Arrange
-    var errorFile = writeToFile("test.txt", List.of("id1,error1", "id2,error2"));
+    var errorFile = writeToFile("test.txt", List.of("error1", "error2"));
     var wireMock = okapi.wireMockServer();
-    final var stub = wireMock.stubFor(post(urlPathEqualTo("/instance-storage/instances/bulk"))
-      .willReturn(ResponseDefinitionBuilder.responseDefinition()
+    final var stub = wireMock
+      .stubFor(post(urlPathEqualTo("/instance-storage/instances/bulk"))
+        .willReturn(ResponseDefinitionBuilder.responseDefinition()
         .withHeader("Content-Type", "application/json;charset=UTF-8")
         .withBody("{ \"errorsNumber\": \"2\", \"errorRecordsFileName\": \"errorRecordsFileName\", "
-                  + "\"errorsFileName\": \"" + errorFile + "\" }")));
-    var migrationOperation = new NewMigrationOperation()
-      .operationType(REMAPPING)
+            + "\"errorsFileName\": \"" + errorFile + "\" }")));
+    var migrationOperation = new NewMigrationOperation().operationType(REMAPPING)
       .entityType(EntityType.INSTANCE);
 
     // Act & Assert
-    var result = doPost(marcMigrationEndpoint(), migrationOperation)
-      .andExpect(operationStatus(NEW))
+    var result = doPost(marcMigrationEndpoint(), migrationOperation).andExpect(operationStatus(NEW))
       .andExpect(totalRecords(11))
       .andReturn();
     var operation = contentAsObj(result, MigrationOperation.class);
     var operationId = operation.getId();
 
-    doGetUntilMatches(marcMigrationEndpoint(operationId),
-      operationStatus(DATA_MAPPING_COMPLETED));
+    doGetUntilMatches(marcMigrationEndpoint(operationId), operationStatus(DATA_MAPPING_COMPLETED));
     doGetUntilMatches(marcMigrationEndpoint(operationId), mappedRecords(11));
 
-    var saveMigrationOperation = new SaveMigrationOperation()
-      .status(DATA_SAVING);
-    tryPut(marcMigrationEndpoint(operationId), saveMigrationOperation)
-      .andExpect(status().isNoContent());
-    awaitUntilAsserted(() ->
-      doGet(marcMigrationEndpoint(operationId))
-        .andExpect(operationStatus(DATA_SAVING_FAILED))
-        .andExpect(totalRecords(11))
-        .andExpect(mappedRecords(11))
-        .andExpect(savedRecords(7))
-    );
+    var saveMigrationOperation = new SaveMigrationOperation().status(DATA_SAVING);
+    tryPut(marcMigrationEndpoint(operationId), saveMigrationOperation).andExpect(status().isNoContent());
+    awaitUntilAsserted(() -> doGet(marcMigrationEndpoint(operationId)).andExpect(operationStatus(DATA_SAVING_FAILED))
+      .andExpect(totalRecords(11))
+      .andExpect(mappedRecords(11))
+      .andExpect(savedRecords(7)));
 
-    doPost(marcMigrationEndpoint(operationId) + "/error-report", null)
-      .andExpect(status().isNoContent());
+    doPost(marcMigrationEndpoint(operationId) + "/error-report", null).andExpect(status().isNoContent());
 
-    awaitUntilAsserted(() ->
-      doGet(marcMigrationEndpoint(operationId) + "/error-report/status")
+    awaitUntilAsserted(() -> doGet(marcMigrationEndpoint(operationId) + "/error-report/status")
         .andExpect(status().isOk())
-        .andExpect(jsonPath("status", is(ErrorReportStatus.StatusEnum.COMPLETED.getValue())))
-    );
+        .andExpect(jsonPath("status", is(ErrorReportStatus.StatusEnum.COMPLETED.getValue()))));
 
-    doGet(marcMigrationEndpoint(operationId) + "/error-report/errors?limit=2&offset=2")
-      .andExpect(status().isOk())
+    doGet(marcMigrationEndpoint(operationId) + "/error-report/errors?limit=2&offset=2").andExpect(status().isOk())
       .andExpect(jsonPath("errorReports", hasSize(2)))
-      .andExpect(jsonPath("errorReports[1].recordId", anyOf(is("id1"), is("id2"))))
+      .andExpect(jsonPath("errorReports[1].recordId", anyOf(is(UNKNOWN_RECORD_ID), is(UNKNOWN_RECORD_ID))))
+      .andExpect(jsonPath("errorReports[1].errorMessage", anyOf(is("error1"), is("error2"))));
+
+    wireMock.removeStubMapping(stub);
+  }
+
+  @Test
+  void createErrorReport_positive_haveErrors() throws Exception {
+    // Arrange
+    var recordId1 = UUID.randomUUID().toString();
+    var recordId2 = UUID.randomUUID().toString();
+    var errorFile = writeToFile("test.txt", List.of(recordId1 + ",error1", recordId2 + ",error2"));
+    var wireMock = okapi.wireMockServer();
+    final var stub = wireMock
+      .stubFor(post(urlPathEqualTo("/instance-storage/instances/bulk"))
+          .willReturn(ResponseDefinitionBuilder.responseDefinition()
+          .withHeader("Content-Type", "application/json;charset=UTF-8")
+          .withBody("{ \"errorsNumber\": \"2\", \"errorRecordsFileName\": \"errorRecordsFileName\", "
+              + "\"errorsFileName\": \"" + errorFile + "\" }")));
+    var migrationOperation = new NewMigrationOperation().operationType(REMAPPING)
+      .entityType(EntityType.INSTANCE);
+
+    // Act & Assert
+    var result = doPost(marcMigrationEndpoint(), migrationOperation).andExpect(operationStatus(NEW))
+      .andExpect(totalRecords(11))
+      .andReturn();
+    var operation = contentAsObj(result, MigrationOperation.class);
+    var operationId = operation.getId();
+
+    doGetUntilMatches(marcMigrationEndpoint(operationId), operationStatus(DATA_MAPPING_COMPLETED));
+    doGetUntilMatches(marcMigrationEndpoint(operationId), mappedRecords(11));
+
+    var saveMigrationOperation = new SaveMigrationOperation().status(DATA_SAVING);
+    tryPut(marcMigrationEndpoint(operationId), saveMigrationOperation).andExpect(status().isNoContent());
+    awaitUntilAsserted(() -> doGet(marcMigrationEndpoint(operationId)).andExpect(operationStatus(DATA_SAVING_FAILED))
+      .andExpect(totalRecords(11))
+      .andExpect(mappedRecords(11))
+      .andExpect(savedRecords(7)));
+
+    doPost(marcMigrationEndpoint(operationId) + "/error-report", null).andExpect(status().isNoContent());
+
+    awaitUntilAsserted(() -> doGet(marcMigrationEndpoint(operationId) + "/error-report/status")
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("status", is(ErrorReportStatus.StatusEnum.COMPLETED.getValue()))));
+
+    doGet(marcMigrationEndpoint(operationId) + "/error-report/errors?limit=2&offset=2").andExpect(status().isOk())
+      .andExpect(jsonPath("errorReports", hasSize(2)))
+      .andExpect(jsonPath("errorReports[1].recordId", anyOf(is(recordId1), is(recordId2))))
       .andExpect(jsonPath("errorReports[1].errorMessage", anyOf(is("error1"), is("error2"))));
 
     wireMock.removeStubMapping(stub);

--- a/src/test/java/org/folio/marc/migrations/services/batch/mapping/MappingRecordsChunkProcessorTest.java
+++ b/src/test/java/org/folio/marc/migrations/services/batch/mapping/MappingRecordsChunkProcessorTest.java
@@ -119,7 +119,7 @@ class MappingRecordsChunkProcessorTest {
     var actualRecords = new ArrayList<>(actual.records());
     assertThat(actualRecords.removeFirst()).matches(result ->
       result.mappedRecord() == null
-        && "test exc".equals(result.errorCause())
+        && result.errorCause().contains("test exc")
         && result.invalidMarcRecord() != null
         && result.invalidMarcRecord().contains("\"version\":1"));
     assertThat(actualRecords).allMatch(result ->
@@ -197,7 +197,7 @@ class MappingRecordsChunkProcessorTest {
       .hasSize(records.size())
       .allMatch(result -> result.mappedRecord() == null
         && result.errorCause() != null
-        && result.errorCause().equals(errorCause)
+        && result.errorCause().contains(errorCause)
         && result.invalidMarcRecord() != null
         && result.invalidMarcRecord().contains(marcRecordContains));
 


### PR DESCRIPTION
### Purpose
[MODMARCMIG-65](https://folio-org.atlassian.net/browse/MODMARCMIG-65) Improve error handling

### Approach

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [x] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Screenshots

1. The field name in the SRS marc_records_lb table was changed from fields to fields1 in the JSONB column to reproduce the issue. Fixed in MappingRecordsChunkProcessor.java.
<kbd>
<img width="1791" height="699" alt="image" src="https://github.com/user-attachments/assets/bb28cd56-86bb-43ea-a05f-170590f41edc" />
</kbd>

---

2. Chunk step error file name is empty:
<kbd>
<img width="991" height="699" alt="image" src="https://github.com/user-attachments/assets/f2b9e69d-46cf-4a58-b090-f5478ded781b" />
</kbd>

---

3. Issue with error generation due to a non-existent file name in S3:
<kbd>
<img width="978" height="498" alt="image" src="https://github.com/user-attachments/assets/ba691d12-26c9-4170-8532-259066726e65" />
</kbd>


