### PR TITLE
refactor: Remove use of deprecated folio-spring-system-user

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
 * Implement spring batch partitioning to support parallel processing in Spring Batch 6 ([MODMARCMIG-107](https://folio-org.atlassian.net/browse/MODMARCMIG-107))
 
 ### Tech Dept
-* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Remove use of deprecated folio-spring-system-user ([MODMARCMIG-109](https://folio-org.atlassian.net/browse/MODMARCMIG-109))
 
 ### Dependencies
 * Bump `LIB_NAME` from `OLD_VERSION` to `NEW_VERSION`

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -3,18 +3,6 @@
   "name": "MARC Migrations",
   "requires": [
     {
-      "id": "login",
-      "version": "7.3"
-    },
-    {
-      "id": "permissions",
-      "version": "5.6"
-    },
-    {
-      "id": "users",
-      "version": "16.0"
-    },
-    {
       "id": "authority-storage",
       "version": "2.0"
     },
@@ -146,18 +134,7 @@
             "POST"
           ],
           "pathPattern": "/_/tenant",
-          "permissionsRequired": [],
-          "modulePermissions": [
-            "users.collection.get",
-            "users.item.post",
-            "users.item.put",
-            "login.item.post",
-            "login.item.delete",
-            "perms.users.get",
-            "perms.users.item.post",
-            "perms.users.assign.immutable",
-            "perms.users.assign.mutable"
-          ]
+          "permissionsRequired": []
         },
         {
           "methods": [
@@ -348,11 +325,6 @@
         "name": "OKAPI_URL",
         "value": "okapi",
         "description": "Okapi URL"
-      },
-      {
-        "name": "SYSTEM_USER_USERNAME",
-        "value": "mod-marc-migrations",
-        "description": "Username for system user"
       },
       {
         "name": "RECORDS_CHUNK_SIZE",

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -82,9 +82,6 @@ docker compose up --build --force-recreate --no-deps
 | DB_INITIALIZATION_FAIL_TIMEOUT   | 30000                    | This property controls whether the pool will "fail fast" if the pool cannot be seeded with an initial connection successfully                                                                                                               |
 | DB_LEAK_DETECTION_THRESHOLD      | 30000                    | This property controls the amount of time that a connection can be out of the pool before a message is logged indicating a possible connection leak (0 - disabled)                                                                          |
 | OKAPI_URL                        | -                        | Okapi URL                                                                                                                                                                                                                                   |
-| SYSTEM_USER_ENABLED              | true                     | Indicate if system user functionality should be enabled                                                                                                                                                                                     |
-| SYSTEM_USER_USERNAME             | mod-marc-migrations      | Username for system user                                                                                                                                                                                                                    |
-| SYSTEM_USER_PASSWORD             | -                        | Password for system user                                                                                                                                                                                                                    |
 | RECORDS_CHUNK_SIZE               | 500                      | Number of records in one chunk for operation processing                                                                                                                                                                                     |
 | CHUNK_FETCH_IDS_COUNT            | 500                      | Number of record ids to fetch per query on chunks preparation phase. RECORDS_CHUNK_SIZE should be a divisor for this in order to maintain proper chunk size                                                                                 |
 | CHUNK_PERSIST_COUNT              | 1_000                    | Number of chunks to be constructed before persisting to db                                                                                                                                                                                  |
@@ -105,9 +102,6 @@ docker compose up --build --force-recreate --no-deps
 ### Folio modules communication
 | Module name               | Interface                 | Notes                                       |
 |---------------------------|---------------------------|---------------------------------------------|
-| mod-login                 | login                     | For system user creation and authentication |
-| mod-permissions           | permissions               | For system user creation                    |
-| mod-users                 | users                     | For system user creation                    |
 | mod-source-record-manager | mapping-metadata-provider | For fetching MARC mapping metadata          |
 | mod-source-record-storage | source-storage-records    | For having access to MARC records           |
 | mod-entities-links        | authority-storage         | For having access to Authority records      |

--- a/docker/app-docker-compose.yml
+++ b/docker/app-docker-compose.yml
@@ -22,7 +22,6 @@ services:
       ENV: ${ENV}
       JAVA_OPTIONS: -Xmx512m -Xms256m
       OKAPI_URL: ${OKAPI_URL}
-      SYSTEM_USER_PASSWORD: mod-marc-migrations
       S3_REGION: ${S3_REGION}
       S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID}
       S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY}

--- a/docker/infra-docker-compose.yml
+++ b/docker/infra-docker-compose.yml
@@ -119,7 +119,6 @@ services:
       ENV: ${ENV}
       JAVA_OPTIONS: -Xmx120m -Xms120m
       OKAPI_URL: ${OKAPI_URL}
-      SYSTEM_USER_PASSWORD: mod-entities-links
     networks:
       - mod-marc-migrations-local
 networks:

--- a/pom.xml
+++ b/pom.xml
@@ -54,12 +54,6 @@
 
     <dependency>
       <groupId>org.folio</groupId>
-      <artifactId>folio-spring-system-user</artifactId>
-      <version>${folio-spring-support.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
       <version>${data-import-processing-core.version}</version>
     </dependency>

--- a/src/main/java/org/folio/marc/migrations/services/operations/OperationErrorReportService.java
+++ b/src/main/java/org/folio/marc/migrations/services/operations/OperationErrorReportService.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
+import java.util.regex.Pattern;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -22,7 +23,6 @@ import org.folio.marc.migrations.services.batch.support.FolioS3Service;
 import org.folio.marc.migrations.services.jdbc.ChunkStepJdbcService;
 import org.folio.marc.migrations.services.jdbc.OperationErrorJdbcService;
 import org.folio.spring.data.OffsetRequest;
-import org.folio.util.UuidUtil;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 
@@ -30,6 +30,9 @@ import org.springframework.stereotype.Service;
 @Service
 public class OperationErrorReportService {
 
+  private static final Pattern UUID_PATTERN =
+    Pattern.compile("[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}",
+      Pattern.CASE_INSENSITIVE);
   private static final String UNKNOWN_RECORD_ID = "<unknown>";
   private static final String ERROR_FILE_NOT_FOUND = "Error file not found for chunk";
   private static final String ERROR_PROCESSING_MESSAGE = "Error while processing error report for chunk step ";
@@ -164,7 +167,7 @@ public class OperationErrorReportService {
   private OperationError createOperationErrorFromLine(String errorLine, ChunkStep chunkStep, Operation operation) {
     var errorMessage = errorLine;
     var recordId = StringUtils.substringBefore(errorLine, ',');
-    if (StringUtils.isBlank(recordId) || !UuidUtil.isUuid(recordId)) {
+    if (StringUtils.isBlank(recordId) || !UUID_PATTERN.matcher(recordId).matches()) {
       recordId = UNKNOWN_RECORD_ID;
     } else {
       errorMessage = StringUtils.substringAfter(errorLine, ',');

--- a/src/main/java/org/folio/marc/migrations/services/tenant/ModuleTenantService.java
+++ b/src/main/java/org/folio/marc/migrations/services/tenant/ModuleTenantService.java
@@ -5,7 +5,6 @@ import org.folio.marc.migrations.services.jdbc.AuthorityJdbcService;
 import org.folio.marc.migrations.services.jdbc.InstanceJdbcService;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.liquibase.FolioSpringLiquibase;
-import org.folio.spring.service.PrepareSystemUserService;
 import org.folio.spring.service.TenantService;
 import org.folio.tenant.domain.dto.TenantAttributes;
 import org.springframework.context.annotation.Primary;
@@ -17,18 +16,15 @@ import org.springframework.stereotype.Service;
 @Primary
 public class ModuleTenantService extends TenantService {
 
-  private final PrepareSystemUserService prepareSystemUserService;
   private final AuthorityJdbcService authorityJdbcService;
   private final InstanceJdbcService instanceJdbcService;
 
   public ModuleTenantService(JdbcTemplate jdbcTemplate,
                              FolioExecutionContext context,
                              FolioSpringLiquibase folioSpringLiquibase,
-                             PrepareSystemUserService prepareSystemUserService,
                              AuthorityJdbcService authorityJdbcService,
                              InstanceJdbcService instanceJdbcService) {
     super(jdbcTemplate, context, folioSpringLiquibase);
-    this.prepareSystemUserService = prepareSystemUserService;
     this.authorityJdbcService = authorityJdbcService;
     this.instanceJdbcService = instanceJdbcService;
   }
@@ -37,7 +33,6 @@ public class ModuleTenantService extends TenantService {
   protected void afterTenantUpdate(TenantAttributes tenantAttributes) {
     log.info("afterTenantUpdate::Initiating additional setup [tenant: {}]", context.getTenantId());
     super.afterTenantUpdate(tenantAttributes);
-    prepareSystemUserService.setupSystemUser();
     authorityJdbcService.initViews(context.getTenantId());
     instanceJdbcService.initViews(context.getTenantId());
     log.info("afterTenantUpdate::Completed additional setup [tenant: {}]", context.getTenantId());

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -55,12 +55,6 @@ spring:
 folio:
   environment: ${ENV:folio}
   okapi-url: ${OKAPI_URL:http://localhost:9130}
-  system-user:
-    enabled: ${SYSTEM_USER_ENABLED:false}
-    username: ${SYSTEM_USER_USERNAME:mod-marc-migrations}
-    password: ${SYSTEM_USER_PASSWORD:mod-marc-migrations}
-    lastname: MARC Migrations
-    permissionsFilePath: permissions/mod-marc-migrations-permissions.csv
   exchange:
     enabled: true
   tenant:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -43,12 +43,6 @@ spring:
 folio:
   environment: ${ENV:folio}
   okapi-url: ${OKAPI_URL:http://localhost:9130}
-  system-user:
-    enabled: ${SYSTEM_USER_ENABLED:false}
-    username: ${SYSTEM_USER_USERNAME:mod-marc-migrations}
-    password: ${SYSTEM_USER_PASSWORD}
-    lastname: MARC Migrations
-    permissionsFilePath: permissions/mod-marc-migrations-permissions.csv
   exchange:
     enabled: true
   tenant:

--- a/src/test/java/org/folio/marc/migrations/services/tenant/ModuleTenantServiceTest.java
+++ b/src/test/java/org/folio/marc/migrations/services/tenant/ModuleTenantServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.when;
 import org.folio.marc.migrations.services.jdbc.AuthorityJdbcService;
 import org.folio.marc.migrations.services.jdbc.InstanceJdbcService;
 import org.folio.spring.FolioExecutionContext;
-import org.folio.spring.service.PrepareSystemUserService;
 import org.folio.spring.testing.type.UnitTest;
 import org.folio.tenant.domain.dto.TenantAttributes;
 import org.junit.jupiter.api.Test;
@@ -21,7 +20,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class ModuleTenantServiceTest {
 
-  private @Mock PrepareSystemUserService systemUserService;
   private @Mock FolioExecutionContext context;
   private @Mock AuthorityJdbcService authorityJdbcService;
   private @Mock InstanceJdbcService instanceJdbcService;
@@ -33,7 +31,6 @@ class ModuleTenantServiceTest {
     when(context.getTenantId()).thenReturn(TENANT_ID);
     assertDoesNotThrow(() -> moduleTenantService.createOrUpdateTenant(new TenantAttributes().moduleTo("mod-1.0.0")));
 
-    verify(systemUserService).setupSystemUser();
     verify(authorityJdbcService).initViews(TENANT_ID);
     verify(instanceJdbcService).initViews(TENANT_ID);
   }


### PR DESCRIPTION
### Purpose
Remove use of deprecated folio-spring-system-user

### Approach
- Remove system user preparation logic
- Remove dependency, configs from yaml
- Add uuid validation for now missing due to a transitive dependency UuidUtil
- Remove interfaces/permissions from module descriptor
- Update documentation
- Update docker-compose files

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODMARCMIG-109](https://folio-org.atlassian.net/browse/MODMARCMIG-109)

 ### Manual testing
- startup successful
- tenant enablement successful
- marc migration for authorities successful